### PR TITLE
chore(deps): TS 5.9 -> 6.0 + tsconfig types fix (closes #40, supersedes #26)

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^25.5.2",
         "jest": "^29",
         "ts-jest": "^29.4.9",
-        "typescript": "^5.0"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4578,9 +4578,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^25.5.2",
     "jest": "^29",
     "ts-jest": "^29.4.9",
-    "typescript": "^5.0"
+    "typescript": "^6.0.3"
   },
   "license": "Apache-2.0"
 }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -122,13 +122,13 @@ export class MnemoClient {
     });
 
     // Handle unexpected exit
-    this.process.on("error", (err) => {
+    this.process.on("error", (err: Error) => {
       this.rejectAllPending(
         new MnemoConnectionError(`Child process error: ${err.message}`),
       );
     });
 
-    this.process.on("exit", (code) => {
+    this.process.on("exit", (code: number | null) => {
       this.connected = false;
       this.rejectAllPending(
         new MnemoConnectionError(
@@ -322,7 +322,7 @@ export class MnemoClient {
       this.pendingRequests.set(id, { resolve, reject });
 
       const payload = JSON.stringify(request) + "\n";
-      this.process.stdin.write(payload, (err) => {
+      this.process.stdin.write(payload, (err: Error | null | undefined) => {
         if (err) {
           this.pendingRequests.delete(id);
           reject(

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
## Summary

Lands TypeScript 6.0 in the SDK. The Dependabot bump (#26) was held in v0.3.3 and v0.3.4 because nobody had actually run `tsc --noEmit` against TS 6.0 — when I did, it surfaced 9 real errors. This PR fixes them.

## What broke under TS 6.0 (vs TS 5.9.3)

\`\`\`
src/index.ts(1,42):   error TS2591: Cannot find name 'node:child_process'
src/index.ts(120,44): error TS2591: Cannot find name 'Buffer'
src/index.ts(415,25): error TS2591: Cannot find name 'Buffer'
src/index.ts(493,23): error TS2503: Cannot find namespace 'NodeJS'
src/index.ts(494,16): error TS2503: Cannot find namespace 'NodeJS'
src/index.ts(494,41): error TS2663: Cannot find name 'process'
src/index.ts(125,31): error TS7006: Parameter 'err' implicitly has an 'any' type
src/index.ts(131,30): error TS7006: Parameter 'code' implicitly has an 'any' type
src/index.ts(325,42): error TS7006: Parameter 'err' implicitly has an 'any' type
\`\`\`

## Fix

1. **\`tsconfig.json\`** — add \`"types": ["node"]\` to \`compilerOptions\`. TS 6.0 stopped auto-resolving ambient Node types; this is the standard migration step for Node-targeting projects.
2. **\`src/index.ts\`** — annotate three internal callback params: \`err: Error\`, \`code: number | null\`, \`err: Error | null | undefined\`. All three are inside private class methods, so they don't surface in \`dist/index.d.ts\` — verified by inspection.
3. **\`package.json\`** — \`typescript: ^5.0\` -> \`^6.0.3\`.

## Validation (post-fix)

- \`npx tsc --noEmit\` clean.
- \`npm test\` 19 / 19 pass.
- \`npm run build\` produces \`dist/{index,types}.{d.ts,d.ts.map,js,js.map}\`.
- Public API surface unchanged: same exports, same class declaration shape in \`dist/index.d.ts\`.

## Test plan

- [ ] Confirm \`npx tsc --noEmit\` exits 0 in CI under \`sdks/typescript/\`.
- [ ] \`npm test\` 19 / 19.
- [ ] \`npm run build\` succeeds.

## Closes

- #40 — TypeScript 6.0 migration tracking.
- #26 — Dependabot PR superseded by this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)