### PR TITLE
chore(npm): scope @mnemo/sdk → @mndfreek/mnemo-sdk (matches existing npm org)

### DIFF
--- a/.github/workflows.pending/README.md
+++ b/.github/workflows.pending/README.md
@@ -78,7 +78,7 @@ Windows wheels are deferred — DuckDB + PyO3 + Windows is a known
 sharp edge, and shipping a wheel that fails at runtime is worse
 than not shipping one. Add after the first PyPI release succeeds.
 
-### `npm-publish.yml.txt` — npm publish (`@mnemo/sdk`)
+### `npm-publish.yml.txt` — npm publish (`@mndfreek/mnemo-sdk`)
 
 Publishes the TypeScript SDK with npm provenance attestation.
 
@@ -87,7 +87,7 @@ Publishes the TypeScript SDK with npm provenance attestation.
 1. The `@mnemo` npm scope must exist and be owned by the publishing
    account: <https://www.npmjs.com/org/create>
 2. `NPM_TOKEN` repo secret — automation token with publish scope
-   for `@mnemo/sdk`:
+   for `@mndfreek/mnemo-sdk`:
    <https://www.npmjs.com/settings/sattyamjjain/tokens>
 3. Create a GitHub repo environment named `npm`.
 

--- a/.github/workflows.pending/npm-publish.yml.txt
+++ b/.github/workflows.pending/npm-publish.yml.txt
@@ -1,7 +1,7 @@
 name: npm-publish
 
 # Publishes the TypeScript SDK at `sdks/typescript/` to npm under the
-# scoped name `@mnemo/sdk`. Uses npm's OIDC provenance attestation
+# scoped name `@mndfreek/mnemo-sdk`. Uses npm's OIDC provenance attestation
 # (introduced 2024) so the published artefact is cryptographically tied
 # to this exact GitHub Actions run.
 #
@@ -10,13 +10,13 @@ name: npm-publish
 #      account. https://www.npmjs.com/org/create
 #   2. `NPM_TOKEN` repo secret — Automation token from
 #      https://www.npmjs.com/settings/<user>/tokens with publish scope
-#      for `@mnemo/sdk`. (npm's full-OIDC trusted publisher exists but
+#      for `@mndfreek/mnemo-sdk`. (npm's full-OIDC trusted publisher exists but
 #      remains less battle-tested than PyPI's; using an automation
 #      token + provenance attestation is the safer default for now.)
 #   3. Create a GitHub repo environment named `npm`.
 #
 # Note
-#   * `package.json` has `"name": "@mnemo/sdk"` — scoped packages need
+#   * `package.json` has `"name": "@mndfreek/mnemo-sdk"` — scoped packages need
 #     `--access public` to be installable without authentication.
 
 on:
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 15
     environment:
       name: npm
-      url: https://www.npmjs.com/package/@mnemo/sdk
+      url: https://www.npmjs.com/package/@mndfreek/mnemo-sdk
     permissions:
       id-token: write   # required for npm provenance attestation
       contents: read

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All integrations are auto-imported via `from mnemo import <ClassName>` — depen
 ### TypeScript
 
 ```typescript
-import { MnemoClient } from "@mnemo/sdk";
+import { MnemoClient } from "@mndfreek/mnemo-sdk";
 
 const client = new MnemoClient({ dbPath: "agent.mnemo.db" });
 await client.connect();

--- a/docs/src/typescript-sdk.md
+++ b/docs/src/typescript-sdk.md
@@ -5,13 +5,13 @@ The TypeScript SDK communicates with Mnemo via MCP STDIO, spawning the `mnemo` b
 ## Installation
 
 ```bash
-npm install @mnemo/sdk
+npm install @mndfreek/mnemo-sdk
 ```
 
 ## Usage
 
 ```typescript
-import { MnemoClient } from '@mnemo/sdk';
+import { MnemoClient } from '@mndfreek/mnemo-sdk';
 
 const client = new MnemoClient({
   dbPath: 'agent.db',

--- a/examples/vercel_ai_sdk_example.ts
+++ b/examples/vercel_ai_sdk_example.ts
@@ -5,7 +5,7 @@
  * TypeScript SDK or directly via MCP.
  *
  * Requirements:
- *   npm install @mnemo/sdk
+ *   npm install @mndfreek/mnemo-sdk
  *   # Or use MCP directly:
  *   npm install ai @ai-sdk/openai
  *   cargo build --release -p mnemo-cli
@@ -14,7 +14,7 @@
 
 // === Option 1: Using Mnemo TypeScript SDK (REST API) ===
 
-import { MnemoClient } from "@mnemo/sdk";
+import { MnemoClient } from "@mndfreek/mnemo-sdk";
 
 async function withMnemoSDK() {
   const client = new MnemoClient({

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,9 +1,9 @@
-# `@mnemo/sdk`
+# `@mndfreek/mnemo-sdk`
 
 TypeScript SDK for [Mnemo](https://github.com/sattyamjjain/mnemo) — an MCP-native memory database for AI agents.
 
 ```bash
-npm install @mnemo/sdk
+npm install @mndfreek/mnemo-sdk
 ```
 
 ## Quick start
@@ -17,7 +17,7 @@ cargo install mnemo-mcp-server   # Rust toolchain required
 Then from your TypeScript app:
 
 ```ts
-import { MnemoClient } from "@mnemo/sdk";
+import { MnemoClient } from "@mndfreek/mnemo-sdk";
 
 const client = new MnemoClient({ dbPath: "agent.mnemo.db" });
 await client.connect();

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mnemo/sdk",
+  "name": "@mndfreek/mnemo-sdk",
   "version": "0.4.0-rc1",
   "description": "TypeScript SDK for Mnemo — MCP-native memory database for AI agents.",
   "main": "dist/index.js",


### PR DESCRIPTION
The `mnemo` npm org wasn't ours — the existing scope is `@mndfreek`. TS SDK now publishes under that scope as `@mndfreek/mnemo-sdk` with no behaviour change. Already shipped: [`@mndfreek/mnemo-sdk@0.4.0-rc1`](https://www.npmjs.com/package/@mndfreek/mnemo-sdk) (manual publish; future versions go through the parked `npm-publish.yml` workflow with provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)