### PR TITLE
chore(v0.4.0-rc2): bump versions + populate PyPI metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0-rc1"
+version = "0.4.0-rc2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sattyamjjain/mnemo"
@@ -87,11 +87,11 @@ pgvector = { version = "0.8.2", features = ["sqlx"] }
 # `version` MUST be present alongside `path` for `cargo publish` to accept
 # these. Path is used for local dev; version is what gets baked into the
 # published crate's manifest. Bump alongside `workspace.package.version`.
-mnemo-core = { path = "crates/mnemo-core", version = "0.4.0-rc1" }
-mnemo-mcp = { path = "crates/mnemo-mcp", version = "0.4.0-rc1" }
-mnemo-postgres = { path = "crates/mnemo-postgres", version = "0.4.0-rc1" }
-mnemo-rest = { path = "crates/mnemo-rest", version = "0.4.0-rc1" }
-mnemo-admin = { path = "crates/mnemo-admin", version = "0.4.0-rc1" }
-mnemo-pgwire = { path = "crates/mnemo-pgwire", version = "0.4.0-rc1" }
-mnemo-grpc = { path = "crates/mnemo-grpc", version = "0.4.0-rc1" }
-mnemo-graph = { path = "crates/mnemo-graph", version = "0.4.0-rc1" }
+mnemo-core = { path = "crates/mnemo-core", version = "0.4.0-rc2" }
+mnemo-mcp = { path = "crates/mnemo-mcp", version = "0.4.0-rc2" }
+mnemo-postgres = { path = "crates/mnemo-postgres", version = "0.4.0-rc2" }
+mnemo-rest = { path = "crates/mnemo-rest", version = "0.4.0-rc2" }
+mnemo-admin = { path = "crates/mnemo-admin", version = "0.4.0-rc2" }
+mnemo-pgwire = { path = "crates/mnemo-pgwire", version = "0.4.0-rc2" }
+mnemo-grpc = { path = "crates/mnemo-grpc", version = "0.4.0-rc2" }
+mnemo-graph = { path = "crates/mnemo-graph", version = "0.4.0-rc2" }

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,61 @@
+# `mnemo-db`
+
+PyPI distribution of [Mnemo](https://github.com/sattyamjjain/mnemo) — an MCP-native memory database for AI agents.
+
+```bash
+pip install mnemo-db
+```
+
+The package directory and import path are still `mnemo` — only the PyPI distribution name has the `-db` suffix because the unqualified `mnemo` is held by an unrelated 2021 notebook project. Your code keeps saying:
+
+```python
+from mnemo import MnemoClient
+```
+
+## Quick start
+
+```python
+from mnemo import MnemoClient
+
+client = MnemoClient(db_path="agent.mnemo.db", agent_id="agent-1")
+
+# Three primitives carry most workflows.
+result = client.remember("The user prefers dark mode", tags=["preference"])
+memories = client.recall("user preferences", limit=5)
+client.forget([result["id"]])
+
+# Mem0-compatible aliases also work:
+# client.add(...), client.search(...), client.delete(...)
+```
+
+## What's in the box
+
+| Surface | What |
+| :-- | :-- |
+| `MnemoClient` | Native PyO3 binding to the Rust engine — DuckDB storage, USearch HNSW vector index, Tantivy full-text index, hybrid retrieval, hash-chained audit log |
+| `MnemoMemoryToolServer` | Anthropic `memory_20250818` 6-op handler. `pip install 'mnemo-db[anthropic-memory-tool]'` |
+| `MnemoLettaShared` | Letta-style Conversations adapter for shared agent memory |
+| `S3Workspace` / `CloudflareR2Workspace` | OpenAI Agents SDK GA snapshot store backends. `pip install 'mnemo-db[openai-sandbox-s3]'` or `[openai-sandbox-r2]` |
+| `MnemoAgentMemory` (OpenAI), `Mem0Compat`, `ASMDCheckpointer` (LangGraph), 12 more | Drop-in framework integrations. Install the matching extra. |
+
+## Optional extras
+
+```bash
+pip install 'mnemo-db[langgraph]'              # LangGraph checkpoint
+pip install 'mnemo-db[crewai]'                 # CrewAI memory
+pip install 'mnemo-db[openai-agents]'          # OpenAI Agents SDK
+pip install 'mnemo-db[claude]'                 # Claude Agent SDK
+pip install 'mnemo-db[anthropic-memory-tool]'  # memory_20250818
+pip install 'mnemo-db[openai-sandbox-s3]'      # S3 workspace backend
+pip install 'mnemo-db[openai-sandbox-r2]'      # Cloudflare R2 workspace backend
+pip install 'mnemo-db[benchmark]'              # LoCoMo / LongMemEval harness
+```
+
+Each extra fails closed if not installed — `from mnemo import MnemoMemoryToolServer` will raise `ImportError` cleanly when `[anthropic-memory-tool]` isn't on the path.
+
+## License + source
+
+Source: <https://github.com/sattyamjjain/mnemo>. Apache-2.0.
+
+Documentation: <https://github.com/sattyamjjain/mnemo#readme>.
+Issues: <https://github.com/sattyamjjain/mnemo/issues>.

--- a/python/mnemo/__init__.py
+++ b/python/mnemo/__init__.py
@@ -12,7 +12,7 @@ Example::
     memories = client.recall("user preferences")
 """
 
-__version__ = "0.4.0rc1"
+__version__ = "0.4.0rc2"
 __all__: list[str] = []
 
 # The native PyO3 extension is optional at import time — users who only need

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,17 +9,49 @@ build-backend = "maturin"
 # the PyPI distribution name moves. Users do `pip install mnemo-db`
 # then `from mnemo import MnemoClient`.
 name = "mnemo-db"
-version = "0.4.0rc1"
+version = "0.4.0rc2"
 description = "MCP-native memory database for AI agents"
+readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
+keywords = [
+    "mnemo",
+    "mcp",
+    "memory",
+    "ai",
+    "agent",
+    "llm",
+    "vector",
+    "embeddings",
+    "knowledge-graph",
+    "duckdb",
+]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
 ]
+
+[project.urls]
+Homepage = "https://github.com/sattyamjjain/mnemo"
+Repository = "https://github.com/sattyamjjain/mnemo"
+Documentation = "https://github.com/sattyamjjain/mnemo#readme"
+"Bug Tracker" = "https://github.com/sattyamjjain/mnemo/issues"
+Changelog = "https://github.com/sattyamjjain/mnemo/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 langgraph = ["langgraph-checkpoint>=0.2"]

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mndfreek/mnemo-sdk",
-  "version": "0.4.0-rc1",
+  "version": "0.4.0-rc2",
   "description": "TypeScript SDK for Mnemo — MCP-native memory database for AI agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
PyPI `mnemo-db@0.4.0rc1` shipped with empty long-description / no URLs / no keywords because pyproject.toml was missing `readme`, `[project.urls]`, and `keywords`. PyPI doesn't allow editing metadata of a published version — the fix is a fresh `0.4.0-rc2` release.

`mnemo-db@0.4.0rc2` is already live on PyPI with full metadata: https://pypi.org/project/mnemo-db/0.4.0rc2/. This PR records the source-of-truth version bump + new `python/README.md` + the [project.urls] block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)