### PR TITLE
chore(ci): rewrite publish workflows for push-to-main + version-changed gating

### DIFF
--- a/.github/workflows.pending/README.md
+++ b/.github/workflows.pending/README.md
@@ -5,106 +5,130 @@ that need a token with `workflow` scope to land. The default
 `sattyamjjain` token lacks that scope, so they get parked here
 until a maintainer with `workflow` scope moves them across.
 
-The v0.3.3 cohort (`benchmarks-nightly` + `security`) was already
-moved out of this directory in PR #43; the steady-state list lives
-below.
-
-## Activation drill (one-time per workflow)
+## Activation drill
 
 ```bash
-git checkout -b chore/activate-<name>
+git checkout -b chore/activate-publish-workflows
 mkdir -p .github/workflows
-git mv .github/workflows.pending/<name>.yml.txt \
-       .github/workflows/<name>.yml
-git commit -m "chore(ci): activate <name> workflow"
-git push -u origin chore/activate-<name>
-gh pr create --base main --head chore/activate-<name> \
-    --title "chore(ci): activate <name>" \
-    --body "Move from workflows.pending/. See the file's top-of-file docs for prerequisites."
-gh pr merge --admin --merge <pr-number>
+for f in cargo-publish pypi-publish npm-publish; do
+  git mv ".github/workflows.pending/${f}.yml.txt" \
+         ".github/workflows/${f}.yml"
+done
+git commit -m "chore(ci): activate auto-publish workflows"
+git push -u origin chore/activate-publish-workflows
+gh pr create --base main --head chore/activate-publish-workflows \
+    --title "chore(ci): activate auto-publish workflows" \
+    --body "Move from workflows.pending/. See README in that directory."
+gh pr merge --admin --merge "$(gh pr list --head chore/activate-publish-workflows --json number -q '.[0].number')"
 ```
 
-A token with `workflow` scope is required for the push step. Either
-refresh the personal token via `gh auth refresh -s workflow`, or do
-the move-and-push from the work account.
+A token with `workflow` scope is required for the push step.
+Either run `gh auth refresh -s workflow` once, or use a fresh PAT.
+
+---
+
+## Trigger model — auto-deploy on push to main
+
+All three workflows trigger on **push to main** (plus
+`workflow_dispatch` for manual reruns). Each runs a
+**version-changed precheck** before any actual publish:
+
+* `cargo-publish.yml` — for each of the 9 internal crates, check
+  `crates.io/api/v1/crates/<crate>/<workspace-version>`. Crates
+  whose current workspace version is already on crates.io get
+  skipped; the rest get queued and published in dependency order.
+* `pypi-publish.yml` — check `pypi.org/pypi/mnemo-db/<version>/json`.
+  Skip if 200, build wheels + publish if 404.
+* `npm-publish.yml` — `npm view @mndfreek/mnemo-sdk@<version>`.
+  Skip if it returns the version, publish otherwise.
+
+What this gives you
+
+* **Doc-only commits don't republish.** No version bump → no
+  publish attempt → no spurious failure.
+* **Version-bump commits publish exactly the channels whose
+  manifest changed.** Bump only `Cargo.toml`? Only crates.io
+  fires. Bump `pyproject.toml` too? PyPI joins. All three? Three
+  parallel publishes.
+* **Idempotent.** Re-running on the same commit is always safe.
+
+What this does NOT give you
+
+* **Auto-version-bumping.** You still edit the version field in
+  `Cargo.toml` / `pyproject.toml` / `package.json` before pushing.
+  No commit-message-driven bump (no semantic-release / changesets).
+* **Automatic CHANGELOG generation.** Manual today.
 
 ---
 
 ## Currently parked
 
-### `cargo-publish.yml.txt` — crates.io publish
+### `cargo-publish.yml.txt` — crates.io
 
-Publishes every public mnemo crate in dependency order on every
-`v*` tag push. Also supports `workflow_dispatch` with a tag input
-and a dry-run flag.
+**Prerequisites**
 
-**Before activating:**
+1. `CARGO_REGISTRY_TOKEN` repo secret. **Set 2026-04-25.** Rotate
+   per normal cadence.
+2. `[workspace.dependencies]` entries in `Cargo.toml` carry
+   `version` alongside `path`. **Already present from PR #56.**
 
-1. `CARGO_REGISTRY_TOKEN` repo secret — generate at
-   <https://crates.io/me> → API Tokens, scope to publish-new +
-   publish-update for every crate name. First publish reserves the
-   name; subsequent publishes update.
-2. The tag's `Cargo.toml` must have `version` specifiers next to
-   `path` on every internal `[workspace.dependencies]` entry. v0.4.0
-   onwards has this; pre-v0.4.0 tags can't be published without
-   re-tagging from a Cargo.toml that does.
-3. Local sanity-check before the first activation:
-   ```bash
-   cargo publish -p mnemo-core --dry-run
-   ```
-   This fails fast on naming conflicts or registry issues without
-   actually publishing.
+**What it publishes**
 
-### `pypi-publish.yml.txt` — PyPI publish (OIDC trusted publisher)
+`mnemo-core` first, then in dep order: `mnemo-graph`, `mnemo-mcp`,
+`mnemo-postgres`, `mnemo-rest`, `mnemo-admin`, `mnemo-pgwire`,
+`mnemo-grpc`, `mnemo-compliance`, then finally `mnemo-mcp-server`
+(the umbrella binary). Each new-crate publish is spaced 12 minutes
+apart to stay under crates.io's free-tier rate limit (5 new crates
+per hour).
 
-Builds maturin wheels for `python/mnemo` (linux + macOS, Python
-3.10–3.13) plus an sdist; publishes via OIDC trusted publishing
-(no API token in repo).
+### `pypi-publish.yml.txt` — PyPI
 
-**Before activating:**
+**Prerequisites**
 
-1. Register `mnemo` on PyPI with a trusted publisher pointing at
-   this repo + the workflow file `pypi-publish.yml` + environment
-   `pypi`:
-   <https://pypi.org/manage/account/publishing/>
-2. Create a GitHub repo environment named `pypi` (Settings →
-   Environments → New environment). No secrets needed inside it —
-   the OIDC token is issued at runtime.
-3. Confirm `python/pyproject.toml` `version` is PyPI-compatible.
-   v0.3.4 and v0.4.0rc1 both work (PyPI normalises `v0.4.0-rc1`
-   to `0.4.0rc1`).
+1. PyPI trusted publisher rule (`mnemo-db` → this repo +
+   `pypi-publish.yml` + env `pypi`). **Already registered** at
+   <https://pypi.org/manage/account/publishing/>.
+2. GitHub repo environment named `pypi`. **Already created.**
 
-Windows wheels are deferred — DuckDB + PyO3 + Windows is a known
-sharp edge, and shipping a wheel that fails at runtime is worse
-than not shipping one. Add after the first PyPI release succeeds.
+Linux + macOS wheels for Python 3.10–3.13 + sdist. Windows
+wheels deferred — DuckDB+PyO3+Windows is a known sharp edge.
 
-### `npm-publish.yml.txt` — npm publish (`@mndfreek/mnemo-sdk`)
+### `npm-publish.yml.txt` — npm
 
-Publishes the TypeScript SDK with npm provenance attestation.
+**Prerequisites**
 
-**Before activating:**
+1. `@mndfreek` npm scope owned by the publishing account.
+   **Already active** (predates our session).
+2. `NPM_TOKEN` repo secret (granular access token with
+   `@mndfreek/*` read+write and **2FA-bypass enabled**).
+   **Set 2026-04-25.**
+3. GitHub repo environment named `npm`. **Already created.**
 
-1. The `@mnemo` npm scope must exist and be owned by the publishing
-   account: <https://www.npmjs.com/org/create>
-2. `NPM_TOKEN` repo secret — automation token with publish scope
-   for `@mndfreek/mnemo-sdk`:
-   <https://www.npmjs.com/settings/sattyamjjain/tokens>
-3. Create a GitHub repo environment named `npm`.
-
-npm's full-OIDC trusted publisher is supported but less battle-
-tested than PyPI's. Token + `--provenance` is the safer default
-for now. Reassess in a release or two.
+Publishes with `--provenance` attestation. Prerelease versions
+(those with a `-` in the version, e.g. `0.4.0-rc2`) ship to the
+`rc` dist-tag so `npm install @mndfreek/mnemo-sdk` keeps resolving
+to the latest stable.
 
 ---
 
-## How to fire a publish run
+## Releasing once activated
 
-After all three workflows are activated and their respective
-prerequisites are configured, a single `git push origin v0.4.0`
-(or whatever the next tag is) triggers all three in parallel.
+Edit the version fields in all relevant manifests, commit, push to
+main:
 
-To publish a tag that already exists (e.g. backfill `v0.4.0` after
-this rewrite lands), use `workflow_dispatch` from the Actions UI
-with the tag name as input. The workflows checkout that tag and
-build from its committed `Cargo.toml` / `pyproject.toml` / npm
-`package.json`.
+```bash
+# Edit:
+#   Cargo.toml workspace.package.version + [workspace.dependencies] internal `version`
+#   python/pyproject.toml [project] version
+#   python/mnemo/__init__.py __version__
+#   sdks/typescript/package.json version
+git commit -am "chore: release 0.4.0"
+git push origin main
+```
+
+The three workflows fire in parallel. Each one prechecks: only the
+channels whose manifest version actually changed will publish.
+
+To re-run after a partial failure (e.g. crates.io rate-limited 4 of 9
+crates), open **Actions → cargo-publish → Run workflow** on the same
+commit. The precheck queues only the unpublished crates.

--- a/.github/workflows.pending/cargo-publish.yml.txt
+++ b/.github/workflows.pending/cargo-publish.yml.txt
@@ -1,100 +1,108 @@
 name: cargo-publish
 
-# Triggered by tag push (`v*`) OR manual dispatch with a specific tag.
-# Publishes every public mnemo crate to crates.io in dependency order.
+# Auto-deploy to crates.io on push to main, gated by version-changed.
+#
+# Trigger model
+#   - push to main: workflow runs, but each crate publishes ONLY if its
+#     `version` (from workspace.package.version) doesn't already exist
+#     on crates.io. A doc-only commit on main is a no-op.
+#   - workflow_dispatch: manual trigger from the Actions UI for one-shot
+#     republishes (e.g. retrying a rate-limited round).
+#
+# Why version-changed gating
+#   crates.io publishes are PERMANENT — once a version is up, you can
+#   only yank (which leaves the slot reserved). Without the version
+#   check, every commit would attempt a republish and fail noisily.
+#   With the check, the workflow is idempotent: re-running on the same
+#   commit is safe.
 #
 # Prerequisites
-#   1. Set `CARGO_REGISTRY_TOKEN` repo secret (https://crates.io/me — "API Tokens").
-#      Token must have publish-new + publish-update scopes for every crate
-#      below; first publish reserves the name.
-#   2. The tag's `Cargo.toml` must carry `version` specifiers alongside `path`
-#      on every internal `[workspace.dependencies]` entry — `cargo publish`
-#      rejects otherwise. v0.4.0-rc1 onwards has this; pre-v0.4.0-rc1 tags
-#      can't be published without a re-tag.
-#
-# Failure modes worth knowing
-#   * crates.io has an eventual-consistency window between `cargo publish`
-#     and the crate appearing in the registry index. The 60-second sleeps
-#     below are conservative; bump if a downstream crate fails with
-#     "could not find `mnemo-core`".
-#   * Publishing a crate whose name was never reserved fails fast — set
-#     CARGO_REGISTRY_TOKEN once and run a `cargo publish --dry-run -p mnemo-core`
-#     locally first to surface naming conflicts before the workflow fires.
+#   - CARGO_REGISTRY_TOKEN repo secret (set 2026-04-25; rotates per
+#     normal token-rotation cadence).
+#   - The workspace.dependencies block in Cargo.toml MUST carry
+#     `version` alongside `path` for each internal crate. Already
+#     present from PR #56.
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish (must already exist on origin), e.g. v0.4.0"
-        required: true
-        type: string
       dry_run:
         description: "Dry-run only (no actual publish)"
         type: boolean
         default: false
 
 jobs:
-  publish:
+  plan:
     if: github.repository == 'sattyamjjain/mnemo'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
+    outputs:
+      to_publish: ${{ steps.diff.outputs.to_publish }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Compute which crates need publishing
+        id: diff
+        run: |
+          set -euo pipefail
+          # Workspace version — single source of truth for all 9 crates.
+          ver=$(grep -E '^version\s*=' Cargo.toml | head -1 | cut -d'"' -f2)
+          echo "workspace version: ${ver}"
+          to_publish=""
+          # Order matters for the actual publish job — list in dep order.
+          for crate in mnemo-core mnemo-graph mnemo-mcp mnemo-postgres \
+                       mnemo-rest mnemo-admin mnemo-pgwire mnemo-grpc \
+                       mnemo-compliance mnemo-mcp-server; do
+            # 200 = already published; 404 = needs publishing.
+            http=$(curl -s -o /dev/null -w "%{http_code}" \
+              "https://crates.io/api/v1/crates/${crate}/${ver}")
+            if [ "$http" = "404" ]; then
+              echo "  ${crate}@${ver} — NOT YET PUBLISHED, queuing"
+              to_publish="${to_publish} ${crate}"
+            else
+              echo "  ${crate}@${ver} — already on crates.io (HTTP ${http}), skipping"
+            fi
+          done
+          echo "to_publish=${to_publish# }" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: plan
+    if: needs.plan.outputs.to_publish != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment:
       name: crates-io
       url: https://crates.io/crates/mnemo-core
-
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
-
       - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-
+      - uses: Swatinem/rust-cache@v2
       - name: Verify workspace builds
         run: cargo build --workspace --exclude mnemo-python
-
-      - name: Publish in dependency order
+      - name: Publish queued crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+          QUEUED: ${{ needs.plan.outputs.to_publish }}
         run: |
-          set -e
-          publish() {
-            local crate="$1"
+          set -euo pipefail
+          # Reorder QUEUED to honour dependency order — mnemo-core first,
+          # then second-tier, then mnemo-mcp-server last. The plan job
+          # already lists in this order so we trust QUEUED's order.
+          for crate in $QUEUED; do
             echo "::group::Publish ${crate}"
             cargo publish -p "${crate}" $DRY_RUN
             echo "::endgroup::"
-          }
-          # Round 1: leaf — every other crate depends on this.
-          publish mnemo-core
-          # crates.io index propagation; skip on dry-run.
-          if [ -z "$DRY_RUN" ]; then
-            echo "Waiting 60s for crates.io to publish mnemo-core..."
-            sleep 60
-          fi
-          # Round 2: direct dependents of mnemo-core (independent of each other).
-          publish mnemo-graph
-          publish mnemo-mcp
-          publish mnemo-postgres
-          publish mnemo-rest
-          publish mnemo-admin
-          publish mnemo-pgwire
-          publish mnemo-grpc
-          publish mnemo-compliance
-          # Wait again before the umbrella binary picks up the freshly
-          # published deps.
-          if [ -z "$DRY_RUN" ]; then
-            echo "Waiting 60s before publishing mnemo-cli..."
-            sleep 60
-          fi
-          # Round 3: umbrella binary that pulls everything together.
-          # Published as `mnemo-mcp-server` because `mnemo-cli` is owned
-          # on crates.io by github.com/watzon/mnemo (a different
-          # LLM-memory-proxy project). The directory and binary name
-          # stay `mnemo`; only the published package name moves.
-          publish mnemo-mcp-server
+            # crates.io has a free-account rate limit of ~5 new crates
+            # per hour. After mnemo-core lands, sleep briefly to let
+            # the index propagate before the next publish that depends
+            # on it.
+            if [ "${crate}" = "mnemo-core" ] && [ -z "$DRY_RUN" ]; then
+              echo "Waiting 60s for crates.io index propagation"
+              sleep 60
+            fi
+            # Stay under the 5/hour ceiling — 12 min between sequential
+            # NEW-crate publishes after the burst.
+            if [ -z "$DRY_RUN" ]; then sleep 720; fi
+          done

--- a/.github/workflows.pending/npm-publish.yml.txt
+++ b/.github/workflows.pending/npm-publish.yml.txt
@@ -1,51 +1,73 @@
 name: npm-publish
 
-# Publishes the TypeScript SDK at `sdks/typescript/` to npm under the
-# scoped name `@mndfreek/mnemo-sdk`. Uses npm's OIDC provenance attestation
-# (introduced 2024) so the published artefact is cryptographically tied
-# to this exact GitHub Actions run.
+# Auto-deploy @mndfreek/mnemo-sdk to npm on push to main, gated by
+# version-changed.
 #
-# Prerequisites
-#   1. The `@mnemo` npm scope must exist and be owned by the publishing
-#      account. https://www.npmjs.com/org/create
-#   2. `NPM_TOKEN` repo secret — Automation token from
-#      https://www.npmjs.com/settings/<user>/tokens with publish scope
-#      for `@mndfreek/mnemo-sdk`. (npm's full-OIDC trusted publisher exists but
-#      remains less battle-tested than PyPI's; using an automation
-#      token + provenance attestation is the safer default for now.)
-#   3. Create a GitHub repo environment named `npm`.
+# Trigger model
+#   - push to main: runs, but only publishes if
+#     `sdks/typescript/package.json`'s version doesn't already exist on
+#     npm. Doc-only commits no-op.
+#   - workflow_dispatch: manual trigger.
 #
-# Note
-#   * `package.json` has `"name": "@mndfreek/mnemo-sdk"` — scoped packages need
-#     `--access public` to be installable without authentication.
+# Why this design
+#   npm rejects republishing the same version (immutable). The
+#   precheck makes the workflow idempotent.
+#
+# Auth
+#   NPM_TOKEN repo secret (granular access token with @mndfreek/* write
+#   + 2FA bypass enabled). npm's full-OIDC trusted publisher exists but
+#   is younger than PyPI's; reassess in a release or two.
+#
+# Provenance attestation
+#   `--provenance` ties the published artefact cryptographically to
+#   this exact GitHub Actions run. Visible on the npm page.
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish (must already exist on origin)"
-        required: true
-        type: string
 
 jobs:
-  publish:
+  plan:
     if: github.repository == 'sattyamjjain/mnemo'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Check if package.json version is already on npm
+        id: check
+        run: |
+          ver=$(node -p 'require("./sdks/typescript/package.json").version')
+          echo "version=${ver}" >> "$GITHUB_OUTPUT"
+          if npm view "@mndfreek/mnemo-sdk@${ver}" version >/dev/null 2>&1; then
+            echo "@mndfreek/mnemo-sdk@${ver} already on npm — skipping"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "@mndfreek/mnemo-sdk@${ver} not on npm — will publish"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: plan
+    if: needs.plan.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
       name: npm
       url: https://www.npmjs.com/package/@mndfreek/mnemo-sdk
     permissions:
-      id-token: write   # required for npm provenance attestation
+      id-token: write   # for npm provenance attestation
       contents: read
 
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -70,4 +92,14 @@ jobs:
         working-directory: sdks/typescript
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+        run: |
+          # Prerelease versions (with a hyphen, e.g. 0.4.0-rc2) ship to
+          # the `rc` dist-tag so `npm install @mndfreek/mnemo-sdk` keeps
+          # resolving to the latest stable. Stable versions ship to
+          # `latest` (the default).
+          ver=$(node -p 'require("./package.json").version')
+          if [[ "$ver" == *-* ]]; then
+            npm publish --access public --provenance --tag rc
+          else
+            npm publish --access public --provenance
+          fi

--- a/.github/workflows.pending/pypi-publish.yml.txt
+++ b/.github/workflows.pending/pypi-publish.yml.txt
@@ -1,41 +1,61 @@
 name: pypi-publish
 
-# Builds maturin wheels for the `mnemo` Python package and publishes
-# them to PyPI via OIDC trusted publishing — no API token in repo
-# secrets.
+# Auto-deploy mnemo-db to PyPI on push to main, gated by version-changed.
 #
-# Prerequisites
-#   1. Register `mnemo` on PyPI (https://pypi.org/manage/account/publishing/)
-#      as a "trusted publisher" pointing at this repo + workflow file
-#      `pypi-publish.yml` + environment `pypi`.
-#   2. Create a GitHub repo environment named `pypi` (Settings →
-#      Environments). No secrets need to live in it; the OIDC token is
-#      issued at runtime and is what PyPI consumes.
-#   3. The Python project's `version` in `python/pyproject.toml` must be
-#      a PyPI-compatible string. v0.3.4 and v0.4.0rc1 both work
-#      (PyPI normalises `v0.4.0-rc1` -> `0.4.0rc1`).
+# Trigger model
+#   - push to main: runs, but only publishes if `python/pyproject.toml`'s
+#     version doesn't already exist on PyPI. Doc-only commits no-op.
+#   - workflow_dispatch: manual trigger.
 #
-# Notes
-#   * Linux + macOS wheels only on first cut — DuckDB + PyO3 + Windows
-#     is a known sharp edge that we'll add in a follow-up once the
-#     primary path is healthy.
-#   * Skips Python 3.9 — was eligible per pyproject `>=3.9` but its EOL
-#     is approaching. Add back if a real consumer asks.
+# Why this design
+#   PyPI rejects republishing the same version (immutable). The
+#   precheck makes the workflow idempotent so re-running on the same
+#   commit is safe.
+#
+# Auth
+#   Trusted publisher (OIDC) — no API token in repo secrets. The trust
+#   relationship is registered at:
+#     https://pypi.org/manage/account/publishing/
+#   pointing at this repo + workflow file `pypi-publish.yml` + env `pypi`.
+#
+# Coverage caveat
+#   linux + macOS wheels (Python 3.10–3.13) + sdist. Windows deferred
+#   (DuckDB+PyO3+Windows is a known sharp edge — shipping a wheel that
+#   fails at runtime is worse than not shipping one).
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish (must already exist on origin)"
-        required: true
-        type: string
 
 jobs:
-  build-linux:
+  plan:
     if: github.repository == 'sattyamjjain/mnemo'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check if pyproject version is already on PyPI
+        id: check
+        run: |
+          ver=$(grep -E '^version\s*=' python/pyproject.toml | head -1 | cut -d'"' -f2)
+          echo "version=${ver}" >> "$GITHUB_OUTPUT"
+          http=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://pypi.org/pypi/mnemo-db/${ver}/json")
+          if [ "$http" = "404" ]; then
+            echo "mnemo-db@${ver} not on PyPI — will publish"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mnemo-db@${ver} already on PyPI (HTTP ${http}) — skipping"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-linux:
+    needs: plan
+    if: needs.plan.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -43,8 +63,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -60,7 +78,8 @@ jobs:
           path: python/dist
 
   build-macos:
-    if: github.repository == 'sattyamjjain/mnemo'
+    needs: plan
+    if: needs.plan.outputs.should_publish == 'true'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -68,8 +87,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -84,12 +101,11 @@ jobs:
           path: python/dist
 
   build-sdist:
-    if: github.repository == 'sattyamjjain/mnemo'
+    needs: plan
+    if: needs.plan.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
       - uses: PyO3/maturin-action@v1
         with:
           working-directory: python
@@ -101,16 +117,14 @@ jobs:
           path: python/dist
 
   publish:
-    needs: [build-linux, build-macos, build-sdist]
+    needs: [plan, build-linux, build-macos, build-sdist]
+    if: needs.plan.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
-    # Belt-and-braces guard: even on workflow_dispatch, only publish when
-    # the dispatched tag exists. Avoids accidental dispatch from a branch.
-    if: github.repository == 'sattyamjjain/mnemo'
     environment:
       name: pypi
-      url: https://pypi.org/p/mnemo
+      url: https://pypi.org/p/mnemo-db
     permissions:
-      id-token: write   # required by OIDC trusted publisher
+      id-token: write   # required for OIDC trusted publisher
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Rewrites the three parked publish workflows so they trigger on push to main (instead of tag push) and gate on a version-changed precheck. See `.github/workflows.pending/README.md` for the full design rationale.

After this merges, the **only remaining step** to make auto-deploy real is the workflow-scope activation (`git mv` from `.pending/` to `workflows/`). I can do that the moment you hand me a workflow-scope token or run `gh auth refresh -s workflow` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)