### PR TITLE
fix(ci): cargo-publish precheck needs User-Agent for crates.io API

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -51,17 +51,28 @@ jobs:
           echo "workspace version: ${ver}"
           to_publish=""
           # Order matters for the actual publish job — list in dep order.
+          # crates.io's API rejects requests without a User-Agent
+          # (returns 403 — see https://crates.io/data-access). Send
+          # one explicitly. Without this, the precheck always sees 403
+          # and silently skips every crate.
+          UA="mnemo-publish-workflow (https://github.com/sattyamjjain/mnemo)"
           for crate in mnemo-core mnemo-graph mnemo-mcp mnemo-postgres \
                        mnemo-rest mnemo-admin mnemo-pgwire mnemo-grpc \
                        mnemo-compliance mnemo-mcp-server; do
             # 200 = already published; 404 = needs publishing.
-            http=$(curl -s -o /dev/null -w "%{http_code}" \
+            http=$(curl -s -A "$UA" -o /dev/null -w "%{http_code}" \
               "https://crates.io/api/v1/crates/${crate}/${ver}")
             if [ "$http" = "404" ]; then
               echo "  ${crate}@${ver} — NOT YET PUBLISHED, queuing"
               to_publish="${to_publish} ${crate}"
+            elif [ "$http" = "200" ]; then
+              echo "  ${crate}@${ver} — already on crates.io, skipping"
             else
-              echo "  ${crate}@${ver} — already on crates.io (HTTP ${http}), skipping"
+              # Anything other than 200/404 is unexpected (rate limit,
+              # server error, or the User-Agent regression returning).
+              # Fail loud rather than silently skipping.
+              echo "  ${crate}@${ver} — unexpected HTTP ${http} from crates.io API; failing"
+              exit 1
             fi
           done
           echo "to_publish=${to_publish# }" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
First push-to-main run of cargo-publish exited 'success' without publishing anything because crates.io's API returns 403 to requests without a User-Agent. The precheck saw 403 for every crate, treated them all as already-published, and emitted an empty queue. Adds the UA header + fails loud on unexpected HTTP codes.