### PR TITLE
chore(deps): tantivy 0.26 + thiserror 2 (mnemo-compliance) + Actions bumps

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload run artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bench-${{ matrix.dataset }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -63,7 +63,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: PyO3/maturin-action@v1
@@ -72,7 +72,7 @@ jobs:
           command: build
           args: --release --out dist -i python${{ matrix.python-version }}
           manylinux: 2_28
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-py${{ matrix.python-version }}
           path: python/dist
@@ -87,7 +87,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: PyO3/maturin-action@v1
@@ -95,7 +95,7 @@ jobs:
           working-directory: python
           command: build
           args: --release --out dist -i python${{ matrix.python-version }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-py${{ matrix.python-version }}
           path: python/dist
@@ -111,7 +111,7 @@ jobs:
           working-directory: python
           command: sdist
           args: --out dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: python/dist
@@ -126,7 +126,7 @@ jobs:
     permissions:
       id-token: write   # required for OIDC trusted publisher
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rmcp = { version = "1.3", features = ["server", "transport-io"] }
 clap = { version = "4", features = ["derive", "env"] }
 
 # Full-text search
-tantivy = "0.25"
+tantivy = "0.26"
 
 # Async trait
 async-trait = "0.1"

--- a/crates/mnemo-compliance/Cargo.toml
+++ b/crates/mnemo-compliance/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
-thiserror = "1.0"
+thiserror = "2.0"
 
 # HTTP client for HttpConsentManager — defer TLS stack choice to workspace-wide reqwest.
 reqwest = { workspace = true }

--- a/crates/mnemo-core/src/search/tantivy_index.rs
+++ b/crates/mnemo-core/src/search/tantivy_index.rs
@@ -123,8 +123,14 @@ impl FullTextIndex for TantivyFullTextIndex {
             .parse_query(query)
             .map_err(|e| Error::Index(e.to_string()))?;
 
+        // tantivy 0.26 made TopDocs ordering explicit. 0.25's
+        // `TopDocs::with_limit(limit)` implicitly ordered by BM25
+        // score; 0.26 requires `.order_by_score()`.
         let top_docs = searcher
-            .search(&parsed_query, &TopDocs::with_limit(limit))
+            .search(
+                &parsed_query,
+                &TopDocs::with_limit(limit).order_by_score(),
+            )
             .map_err(|e| Error::Index(e.to_string()))?;
 
         let mut results = Vec::new();


### PR DESCRIPTION
Bundles four Dependabot PRs in one local commit so we close them all at once and keep main monotonic.

| Closes | What |
|---|---|
| #46 | actions/setup-python v5 → v6 |
| #47 | actions/upload-artifact v4 → v7 (also paired download-artifact) |
| #51 | thiserror 1.0 → 2.0 in mnemo-compliance (workspace was already on 2.0) |
| #52 | tantivy 0.25 → 0.26 (one-line API migration: `.order_by_score()` for TopDocs) |

#48 (@types/node patch) merged separately as a tiny lockfile bump. #11/#12/#13 were closed earlier as already-absorbed in v0.3.3 PR #55. Remaining open: #22 (jest 29→30 — needs separate validation against ts-jest 29 compatibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)