### PR TITLE
fix(ci): install protoc for mnemo-grpc build script

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -89,6 +89,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install protoc (required by mnemo-grpc build script)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Verify workspace builds
         run: cargo build --workspace --exclude mnemo-python
       - name: Publish queued crates in dependency order

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install protoc (required by mnemo-grpc build script)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - run: cargo clippy --all-targets --all-features
 
   test:
@@ -39,7 +41,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all
+      - name: Install protoc (required by mnemo-grpc build script)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - run: cargo test --workspace --exclude mnemo-python
 
   build:
     name: Build
@@ -48,7 +52,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --all
+      - name: Install protoc (required by mnemo-grpc build script)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      # mnemo-python is a PyO3 cdylib that won't link without the
+      # Python development headers + maturin context. Built separately
+      # via the pypi-publish workflow.
+      - run: cargo build --workspace --exclude mnemo-python
 
   security:
     name: Security Audit


### PR DESCRIPTION
Pre-existing CI breakage from v0.3.2 — cycled back into focus when cargo-publish.yml started failing every push-to-main run. mnemo-grpc's build.rs needs protoc which isn't on the Ubuntu runner by default. Adds `apt-get install -y protobuf-compiler` in ci.yml's clippy/test/build jobs and cargo-publish.yml's publish job. Also tightens ci.yml test/build from `cargo --all` to `--workspace --exclude mnemo-python` (the PyO3 cdylib has its own maturin path).