### PR TITLE
feat(v0.4.3)!: duckdb 1.5.2 + cloudflare DO Facets anchor + MCP SDK matrix row + spec-drift reconciliation

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -84,10 +84,12 @@ jobs:
     needs: plan
     if: needs.plan.outputs.to_publish != ''
     runs-on: ubuntu-latest
-    # 11 workspace crates × 12-min crates.io rate-limit spacing ≈ 132 min
-    # worst-case. Pad to 180 so a fresh-version run that has to walk
-    # every crate is not killed by GitHub's job timeout mid-sequence.
-    timeout-minutes: 180
+    # 17 workspace crates × 12-min crates.io rate-limit spacing ≈ 204 min,
+    # plus 30-60s of compile + upload per crate. The v0.4.2 publish hit
+    # the prior 180-min cap (cancelled at 183 min, 10/17 crates done) and
+    # required a manual workflow_dispatch resume. Pad to 300 so a fresh-
+    # version run that has to walk every crate completes in one shot.
+    timeout-minutes: 300
     environment:
       name: crates-io
       url: https://crates.io/crates/mnemo-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Mnemo are documented in this file.
 
+## [Unreleased]
+
+### ⚠️  Breaking — persisted state upgrade required
+
+- **Bumped `duckdb` 1.4 → 1.5.2** (closes [#41](https://github.com/sattyamjjain/mnemo/issues/41) Step 1; PR [#75](https://github.com/sattyamjjain/mnemo/pull/75)).
+  DuckDB 1.5.2 stamps a newer on-disk file-format header. **Operators
+  upgrading mnemo across this version must:**
+  1. **Back up** any persisted `*.mnemo.db` file (and the sibling
+     `*.usearch` / `*.tantivy` index directories) before running the
+     new binary.
+  2. **Open the DB once with the new binary** to upgrade the file
+     format in place. Once upgraded, the file is no longer readable
+     by mnemo binaries pinned to duckdb 1.4.x — downgrading after
+     this point requires a fresh DB.
+  3. If a downgrade is required, restore from the pre-upgrade backup
+     in step 1.
+  4. **No operator action is required for fresh DBs** — the new
+     binary writes the new format on first open.
+
+  See the upstream [DuckDB 1.5.2 release notes](https://duckdb.org/2026/04/13/announcing-duckdb-152)
+  and the [`duckdb-rs` 1.10502.0 release](https://github.com/duckdb/duckdb-rs/releases) for full file-format change details.
+
+### Changed
+
+- **Migrations are now idempotent under DuckDB 1.5+** (PR [#75](https://github.com/sattyamjjain/mnemo/pull/75)).
+  The previous "issue ALTER, swallow column-exists error" pattern in
+  `run_migrations` no longer works — DuckDB 1.5 aborts the
+  connection's implicit transaction after a few consecutive failures.
+  New `apply_alters_idempotent` introspects
+  `information_schema.columns` first and only emits an `ALTER` when
+  the column is actually missing. Side benefit: also resolves the
+  pre-existing Ubuntu DuckDB extension race that was admin-merged
+  through every prior release.
+
 ## [0.4.2] - 2026-05-03
 
 Reconciliation release. Three S-effort surfaces driven by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,77 @@
 
 All notable changes to Mnemo are documented in this file.
 
-## [Unreleased]
+## [0.4.3] - 2026-05-04
+
+Substrate-anchor release. Three S-effort surfaces: a Cloudflare
+Workers / Durable Object Facets deploy-template *design anchor*
+(net-new market trigger from the 2026-04-30 DO Facets open beta), a
+version-skew matrix expansion to track the 2026-05-01 / 2026-05-02
+MCP client-SDK refresh, and a spec-drift reconciliation note that
+pins the repo description on `main` as canonical against an external
+skill-template anchor. Also lands the load-bearing **breaking change**
+that's been gated for two release cycles: `duckdb` 1.4 → 1.5.2
+(closes [#41](https://github.com/sattyamjjain/mnemo/issues/41) Step 1)
+with a fully idempotent migration runner that incidentally resolves
+the pre-existing Ubuntu DuckDB extension race.
+
+### Added
+
+- **A1 — Cloudflare Workers / Durable Object Facets deploy template anchor.**
+  README `### Cloudflare Workers deploy template` subsection under
+  Deployment, citing the [DO Facets open-beta](https://blog.cloudflare.com/durable-object-facets-dynamic-workers/)
+  (2026-04-30) as the substrate anchor for the v0.4.3 `mnemo-bench-cf`
+  crate. New design note at
+  [`docs/src/integrations/cloudflare-workers-deploy.md`](docs/src/integrations/cloudflare-workers-deploy.md)
+  covering Rust↔WASM↔DO-Facet boundaries, file-format compatibility
+  (DuckDB ↔ SQLite is *not* wire-compatible), operator-held HMAC
+  keystore requirement, and the open-question list (USearch-on-WASM,
+  Tantivy-on-WASM, DuckDB-on-WASM trade-offs).
+  [`docs/comparisons/cloudflare-agent-memory.md`](docs/comparisons/cloudflare-agent-memory.md)
+  S1.5 row replaces empty-bench placeholders with a concrete
+  per-tenant-footprint / cold-start / persistence-boundary /
+  audit-replay scenario block. Two new tests: extended marketing-phrase
+  banlist (`tests/readme_no_marketing_phrases.rs` adds `viral`,
+  `game-changing`, `revolutionary`, `wild`, `mind-blowing`, etc.) and
+  `tests/readme_workers_template_link.rs` (anchor-link survival test).
+
+### Changed
+
+- **U1 — version-skew matrix gains MCP-SDK columns + a
+  Cloudflare-substrate annotation.**
+  [`docs/compat/version-skew-matrix.md`](docs/compat/version-skew-matrix.md)
+  now splits server-side and SDK-side rows; new `mcp-python` /
+  `mcp-go` / `mcp-ruby` / `mcp-csharp` columns track the 2026-05-01 /
+  05-02 client-SDK refresh from
+  [github.com/modelcontextprotocol](https://github.com/modelcontextprotocol).
+  The v0.4.3 row carries a Cloudflare-substrate annotation listing
+  both Workers KV+Vectorize *and* DO Facets SQLite as
+  `mnemo-bench-cf` baseline targets (not implementation-of-record —
+  mnemo still ships embedded Rust). New regression test
+  `crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs` fails if the doc
+  is missing or loses any of the four `mcp-*` column headers.
+  `docs/src/integrations/mcp-server.md` gains a "Compatibility note"
+  section linking to the matrix for SDK-skew triage.
+
+- **U2 — spec-drift reconciliation note.**
+  New [`docs/spec-drift-2026-05-04.md`](docs/spec-drift-2026-05-04.md)
+  declares the repo description on `main` canonical (vs. the
+  daily-opportunity-radar skill template's older description) and
+  maps the skill template's surface anchors (semantic + episodic
+  stores, LangGraph adapter, Workers template) to where they live in
+  the actual codebase. `CONTRIBUTING.md` gains a "Spec-drift policy"
+  subsection linking to the note so future contributors landing
+  surface-affecting changes find the policy first.
+
+### Verification trace (2026-05-04)
+
+- `Cargo.toml` workspace.package.version = `"0.4.2"` on `main` ✓
+- README role-filter section live (v0.4.2 A1) ✓
+- README Cloudflare differentiation H2 live (v0.4.2 U2) ✓
+- `tests/readme_no_marketing_phrases.rs` green on `main` ✓
+- All 17 crates published at `0.4.2` on crates.io ✓
+- `mnemo-db@0.4.2` on PyPI ✓
+- `@mndfreek/mnemo-sdk@0.4.2` on npm ✓
 
 ### ⚠️  Breaking — persisted state upgrade required
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,31 @@ Use the [GitHub Issues](https://github.com/sattyamjjain/mnemo/issues) tab with t
 
 Use the [GitHub Issues](https://github.com/sattyamjjain/mnemo/issues) tab with the feature request template.
 
+## Spec-drift policy
+
+The daily-product-prompt pipeline that generates this repo's release
+schedule runs against an external skill template whose anchored
+description sometimes drifts from this repo's actual description.
+The repo description on `main` is **canonical** — see
+[`docs/spec-drift-2026-05-04.md`](docs/spec-drift-2026-05-04.md) for
+the recorded reconciliation, the rationale, and the mapping from
+skill-template surface anchors to where each one actually lives in
+this codebase.
+
+**If you are landing a surface-affecting change** (renaming a public
+crate, removing a primary API, changing the wire-protocol version,
+deprecating a backend), please:
+
+1. Read `docs/spec-drift-*.md` — the most-recent file is the active
+   reconciliation.
+2. If your change widens the divergence (the skill template would now
+   be even more wrong), file a new `docs/spec-drift-<date>.md` in the
+   same PR and update the link from this section.
+3. If your change *narrows* the divergence (e.g. landing the actual
+   `mnemo-langgraph` Rust adapter the skill template anticipated),
+   call that out explicitly in the PR body so the schedule pipeline
+   can retire that anchor row.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,11 @@ hmac = "0.13"
 hex = "0.4"
 
 # Storage
-duckdb = { version = "1.4", features = ["bundled"] }
+# duckdb-rs re-versioned to a calendar-style scheme aligned with the
+# underlying DuckDB engine: 1.10502.0 wraps DuckDB 1.5.2 (year 1,
+# month 05, patch 02). See https://github.com/duckdb/duckdb-rs/releases.
+# Tracked at #41 (Step 1 — bump; Step 2 — DuckLake opt-in deferred to v0.5.x).
+duckdb = { version = "=1.10502.0", features = ["bundled"] }
 
 # Vector index
 usearch = "2.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sattyamjjain/mnemo"
@@ -100,11 +100,11 @@ pgvector = { version = "0.8.2", features = ["sqlx"] }
 # `version` MUST be present alongside `path` for `cargo publish` to accept
 # these. Path is used for local dev; version is what gets baked into the
 # published crate's manifest. Bump alongside `workspace.package.version`.
-mnemo-core = { path = "crates/mnemo-core", version = "0.4.2" }
-mnemo-mcp = { path = "crates/mnemo-mcp", version = "0.4.2" }
-mnemo-postgres = { path = "crates/mnemo-postgres", version = "0.4.2" }
-mnemo-rest = { path = "crates/mnemo-rest", version = "0.4.2" }
-mnemo-admin = { path = "crates/mnemo-admin", version = "0.4.2" }
-mnemo-pgwire = { path = "crates/mnemo-pgwire", version = "0.4.2" }
-mnemo-grpc = { path = "crates/mnemo-grpc", version = "0.4.2" }
-mnemo-graph = { path = "crates/mnemo-graph", version = "0.4.2" }
+mnemo-core = { path = "crates/mnemo-core", version = "0.4.3" }
+mnemo-mcp = { path = "crates/mnemo-mcp", version = "0.4.3" }
+mnemo-postgres = { path = "crates/mnemo-postgres", version = "0.4.3" }
+mnemo-rest = { path = "crates/mnemo-rest", version = "0.4.3" }
+mnemo-admin = { path = "crates/mnemo-admin", version = "0.4.3" }
+mnemo-pgwire = { path = "crates/mnemo-pgwire", version = "0.4.3" }
+mnemo-grpc = { path = "crates/mnemo-grpc", version = "0.4.3" }
+mnemo-graph = { path = "crates/mnemo-graph", version = "0.4.3" }

--- a/README.md
+++ b/README.md
@@ -332,6 +332,28 @@ helm install mnemo deploy/helm/mnemo \
 
 The Helm chart includes: Deployment, Service, ConfigMap, Secret, PVC, HPA, and Ingress templates.
 
+### Cloudflare Workers deploy template (design anchor)
+
+> **Status:** *design anchor*, not a shipped template. The `deploy/cloudflare/` scaffold is parked for v0.4.3 follow-up. This section documents the contract that scaffold will produce against — see [`docs/src/integrations/cloudflare-workers-deploy.md`](docs/src/integrations/cloudflare-workers-deploy.md) for the full design note.
+
+[Cloudflare Durable Object Facets](https://blog.cloudflare.com/durable-object-facets-dynamic-workers/) (open beta, 2026-04-30) lets a single Worker dynamically load Durable Object classes, each with its own SQLite database. That's the per-tenant embedded-substrate shape mnemo already runs on DuckDB-per-agent — making Workers the natural managed runtime for an mnemo MCP server when you don't want to operate the box yourself.
+
+The intended layout (single Worker, one DO Facet per tenant, mnemo as the MCP-over-HTTP entrypoint):
+
+```toml
+# wrangler.toml (sketch — not yet shipped under deploy/cloudflare/)
+name = "mnemo-mcp-worker"
+main = "dist/worker.js"
+
+[[durable_objects.bindings]]
+name = "MNEMO_TENANT"
+class_name = "MnemoTenantFacet"
+# DO Facet — each instance gets its own SQLite-backed storage
+# matching mnemo's embedded DuckDB-per-agent contract.
+```
+
+What stays Rust-native vs. crosses the JS boundary, the file-format compatibility story (mnemo writes DuckDB; the Workers Facet exposes SQLite — the bench crate quantifies the gap), and which mnemo surfaces require the operator-held HMAC keystore vs. which can run inside the Worker — all in [`docs/src/integrations/cloudflare-workers-deploy.md`](docs/src/integrations/cloudflare-workers-deploy.md). The bench numbers land with the v0.4.3 `mnemo-bench-cf` crate.
+
 ## Development
 
 ```bash

--- a/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
+++ b/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
@@ -14,9 +14,24 @@
 use std::path::Path;
 
 const BANNED_PHRASES: &[&str] = &[
+    // v0.4.2 (U2) — Cloudflare-comparison banned framing.
     "beat Cloudflare",
     "faster than Cloudflare",
     "Cloudflare killer",
+    // v0.4.3 (A1) — extended canonical banned-phrases ledger. The
+    // operator's running policy ("ship one row honestly over five rows
+    // aspirationally") rules out every form of viral / breakthrough /
+    // game-changing framing in the README. Per-claim primary-source
+    // links, honest concessions, and bench numbers are the substrates
+    // we promote.
+    "blow up",
+    "viral",
+    "game-changing",
+    "game changing",
+    "revolutionary",
+    "wild",
+    "mind-blowing",
+    "mind blowing",
 ];
 
 #[test]

--- a/crates/mnemo-cli/tests/readme_workers_template_link.rs
+++ b/crates/mnemo-cli/tests/readme_workers_template_link.rs
@@ -1,0 +1,42 @@
+//! v0.4.3 (A1) — README's Cloudflare Workers section must keep its
+//! primary-source link to the 2026-04-30 Durable Object Facets open-beta
+//! announcement. A future README rewrite that drops the anchor will
+//! fail this test before it can land.
+
+use std::path::Path;
+
+const PRIMARY_SOURCE: &str = "https://blog.cloudflare.com/durable-object-facets-dynamic-workers/";
+const SECTION_HEADING: &str = "Cloudflare Workers deploy template";
+const DESIGN_NOTE_PATH: &str = "docs/src/integrations/cloudflare-workers-deploy.md";
+
+fn read_readme() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("README.md");
+    std::fs::read_to_string(&path).expect("README.md must be readable from repo root")
+}
+
+#[test]
+fn workers_section_keeps_primary_source_link() {
+    let body = read_readme();
+    assert!(
+        body.contains(PRIMARY_SOURCE),
+        "README.md must keep the Cloudflare DO Facets primary-source URL ({PRIMARY_SOURCE}). \
+         The Workers deploy-template section without a primary-source anchor would be a \
+         marketing claim, not a technical pointer."
+    );
+}
+
+#[test]
+fn workers_section_has_heading_and_design_note_link() {
+    let body = read_readme();
+    assert!(
+        body.contains(SECTION_HEADING),
+        "README.md must keep the `### {SECTION_HEADING}` subsection (v0.4.3 A1)."
+    );
+    assert!(
+        body.contains(DESIGN_NOTE_PATH),
+        "README.md must keep its link to {DESIGN_NOTE_PATH} so readers can reach the design note from the Deployment section."
+    );
+}

--- a/crates/mnemo-core/src/storage/migrations.rs
+++ b/crates/mnemo-core/src/storage/migrations.rs
@@ -217,21 +217,23 @@ pub fn run_migrations(conn: &duckdb::Connection) -> duckdb::Result<()> {
     conn.execute_batch(CREATE_RELATIONS_TABLE)?;
     conn.execute_batch(CREATE_AGENT_EVENTS_TABLE)?;
     conn.execute_batch(CREATE_CHECKPOINTS_TABLE)?;
-    // Sprint 3 column upgrades — silently ignore if columns already exist
-    for alter_sql in SPRINT3_COLUMN_ALTERS {
-        let _ = conn.execute(alter_sql, []);
-    }
+    // Sprint 3 column upgrades. v0.4.2 (#41 Step 1): switched from
+    // "try ALTER, swallow column-exists error" to schema introspection.
+    // DuckDB 1.5+ aborts the connection's implicit transaction after a
+    // few consecutive `let _ = conn.execute(...)` failures, leaving the
+    // connection unusable. Checking `duckdb_columns` first keeps every
+    // ALTER honest and the connection clean.
+    apply_alters_idempotent(conn, SPRINT3_COLUMN_ALTERS)?;
     conn.execute_batch(CREATE_DELEGATIONS_TABLE)?;
     conn.execute_batch(CREATE_AGENT_PROFILES_TABLE)?;
-    // Sprint 4 column upgrades — silently ignore if columns already exist
-    for alter_sql in SPRINT4_COLUMN_ALTERS {
-        let _ = conn.execute(alter_sql, []);
-    }
-    // Create parent_event_id index if missing
-    let _ = conn.execute(
+    // Sprint 4 column upgrades.
+    apply_alters_idempotent(conn, SPRINT4_COLUMN_ALTERS)?;
+    // Create parent_event_id index if missing — `IF NOT EXISTS` is
+    // first-class, no introspection required.
+    conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_events_parent ON agent_events(parent_event_id)",
         [],
-    );
+    )?;
     // Sprint 8: sync watermarks table
     conn.execute_batch(CREATE_SYNC_METADATA_TABLE)?;
     // v0.3.2: persistence-version stamp.
@@ -239,6 +241,55 @@ pub fn run_migrations(conn: &duckdb::Connection) -> duckdb::Result<()> {
     // v0.3.3: embedding baseline table (z-score outlier detector).
     conn.execute_batch(CREATE_EMBEDDING_BASELINE_TABLE)?;
     stamp_persistence_version(conn)?;
+    Ok(())
+}
+
+/// Parse `ALTER TABLE <name> ADD COLUMN <col> ...` into `(table, col)`.
+/// All migration ALTERs in this file follow that exact shape; anything
+/// else is rejected at compile-test time by [`tests::sprint_alters_match_expected_shape`].
+fn parse_alter_table_add_column(sql: &str) -> Option<(&str, &str)> {
+    let trimmed = sql.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let prefix = "alter table ";
+    let rest = lower.strip_prefix(prefix)?;
+    let after_table_keyword_idx = prefix.len();
+    let table_end = rest.find(' ')?;
+    let table = &trimmed[after_table_keyword_idx..after_table_keyword_idx + table_end];
+    let after_table = &lower[after_table_keyword_idx + table_end..];
+    let add_column = " add column ";
+    let after_add = after_table.strip_prefix(add_column)?;
+    let col_end = after_add.find(' ')?;
+    let col_start_in_full = after_table_keyword_idx + table_end + add_column.len();
+    let col = &trimmed[col_start_in_full..col_start_in_full + col_end];
+    Some((table, col))
+}
+
+/// True when `column` exists on `table` per DuckDB's information_schema.
+fn column_exists(conn: &duckdb::Connection, table: &str, column: &str) -> duckdb::Result<bool> {
+    let mut stmt = conn.prepare(
+        "SELECT 1 FROM information_schema.columns \
+         WHERE lower(table_name) = lower(?) AND lower(column_name) = lower(?) LIMIT 1",
+    )?;
+    let mut rows = stmt.query(duckdb::params![table, column])?;
+    Ok(rows.next()?.is_some())
+}
+
+/// Run a list of `ALTER TABLE ... ADD COLUMN` statements, skipping any
+/// whose column already exists. Returns an error on any *real* failure
+/// (parse error, table missing, type mismatch); column-already-exists
+/// is no longer reachable.
+fn apply_alters_idempotent(conn: &duckdb::Connection, alters: &[&str]) -> duckdb::Result<()> {
+    for sql in alters {
+        let Some((table, column)) = parse_alter_table_add_column(sql) else {
+            return Err(duckdb::Error::ToSqlConversionFailure(
+                format!("migration ALTER did not match expected shape: {sql:?}").into(),
+            ));
+        };
+        if column_exists(conn, table, column)? {
+            continue;
+        }
+        conn.execute(sql, [])?;
+    }
     Ok(())
 }
 
@@ -334,6 +385,39 @@ mod tests {
             read_persistence_version(&conn).unwrap(),
             Some(CURRENT_PERSISTENCE_VERSION)
         );
+    }
+
+    #[test]
+    fn sprint_alters_match_expected_shape() {
+        // v0.4.2 (#41 Step 1): `apply_alters_idempotent` parses
+        // `ALTER TABLE <t> ADD COLUMN <c> ...` to introspect existence.
+        // If a future migration adds a non-matching shape (e.g. a
+        // multi-column ALTER), this test catches it before run-time.
+        for sql in SPRINT3_COLUMN_ALTERS
+            .iter()
+            .chain(SPRINT4_COLUMN_ALTERS.iter())
+        {
+            let parsed = parse_alter_table_add_column(sql);
+            assert!(
+                parsed.is_some(),
+                "ALTER does not match `ALTER TABLE <t> ADD COLUMN <c> ...`: {sql:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn alters_are_idempotent_under_duckdb_152() {
+        // v0.4.2 (#41 Step 1): regression for the duckdb-rs 1.10502
+        // transaction-abort behaviour. Running migrations twice on
+        // the same connection used to leave the connection in an
+        // aborted-transaction state. Now must be a clean no-op.
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        run_migrations(&conn).unwrap();
+        // And a real query afterwards must succeed.
+        let mut stmt = conn.prepare("SELECT COUNT(*) FROM memories").unwrap();
+        let n: i64 = stmt.query_row([], |row| row.get(0)).unwrap();
+        assert_eq!(n, 0);
     }
 
     #[test]

--- a/crates/mnemo-core/tests/version_metadata.rs
+++ b/crates/mnemo-core/tests/version_metadata.rs
@@ -9,11 +9,11 @@
 //! [docs/compat/version-skew-matrix.md](../../docs/compat/version-skew-matrix.md).
 
 #[test]
-fn cargo_pkg_version_matches_v0_4_2() {
+fn cargo_pkg_version_matches_v0_4_3() {
     assert_eq!(
         env!("CARGO_PKG_VERSION"),
-        "0.4.2",
-        "mnemo-core CARGO_PKG_VERSION drifted from the v0.4.2 cut. \
+        "0.4.3",
+        "mnemo-core CARGO_PKG_VERSION drifted from the v0.4.3 cut. \
          Bump `workspace.package.version` in /Cargo.toml AND update \
          docs/compat/version-skew-matrix.md to match."
     );

--- a/crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs
+++ b/crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs
@@ -1,0 +1,57 @@
+//! v0.4.3 (U1) — `docs/compat/version-skew-matrix.md` survival test.
+//!
+//! Catches accidental doc deletion or column-rename ahead of an
+//! SDK-bump release. The matrix is the canonical source of truth for
+//! which client-SDK versions are tested against which mnemo cut; if it
+//! disappears or loses the four `mcp-*` column headers, future SDK
+//! triage breaks silently. Failing the build is the right answer.
+
+use std::path::Path;
+
+const REQUIRED_HEADERS: &[&str] = &["mcp-python", "mcp-go", "mcp-ruby", "mcp-csharp"];
+
+#[test]
+fn skew_matrix_doc_exists_and_carries_required_columns() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("docs")
+        .join("compat")
+        .join("version-skew-matrix.md");
+    let body = std::fs::read_to_string(&path).expect(
+        "docs/compat/version-skew-matrix.md must exist — it is the canonical \
+         server-vs-SDK skew reference. Restore from `main` if missing.",
+    );
+    let mut missing: Vec<&'static str> = Vec::new();
+    for h in REQUIRED_HEADERS {
+        if !body.contains(h) {
+            missing.push(h);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "docs/compat/version-skew-matrix.md is missing required column header(s): \
+         {missing:?}. The matrix's MCP-SDK columns are load-bearing for the \
+         v0.4.3 + later client-SDK skew triage; do not remove them."
+    );
+}
+
+#[test]
+fn skew_matrix_doc_carries_cloudflare_substrate_annotation() {
+    // v0.4.3 also splits the Cloudflare substrate row into Workers
+    // KV+Vectorize vs DO Facets SQLite — the bench crate baselines
+    // both. The annotation must survive future doc rewrites so the
+    // mnemo-bench-cf author has a single source of truth.
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("docs")
+        .join("compat")
+        .join("version-skew-matrix.md");
+    let body = std::fs::read_to_string(&path).expect("matrix doc readable");
+    assert!(
+        body.contains("DO Facets") || body.contains("Durable Object Facets"),
+        "docs/compat/version-skew-matrix.md must mention the DO Facets \
+         substrate annotation introduced in v0.4.3 (U1)."
+    );
+}

--- a/docs/comparisons/cloudflare-agent-memory.md
+++ b/docs/comparisons/cloudflare-agent-memory.md
@@ -35,10 +35,24 @@ auditable, and whose storage survives any specific cloud account**.
 
 | System | Recall p50 | Recall p99 | Notes |
 |---|---|---|---|
-| Cloudflare Agent Memory (Workers KV + Vectorize) | TBD (v0.4.3 bench) | TBD | Edge-cached recall path |
+| Cloudflare Agent Memory (Workers KV + Vectorize) | TBD (v0.4.3 bench) | TBD | Edge-cached recall path; hosted vector index |
+| Cloudflare DO Facets (SQLite-per-DO) | TBD (v0.4.3 bench) | TBD | Per-tenant embedded SQLite — closest analogue to mnemo's per-agent DuckDB; open beta 2026-04-30 ([source](https://blog.cloudflare.com/durable-object-facets-dynamic-workers/)) |
 | mnemo (DuckDB embedded) | ~4ms (LoCoMo nightly) | TBD | Local DuckDB + USearch |
 
-**Honest call:** Cloudflare likely wins this row.
+**Honest call:** Cloudflare KV+Vectorize likely wins on edge throughput. DO Facets SQLite vs DuckDB-per-agent is the substrate-level comparison — same per-tenant embedded shape, different engine.
+
+### S1.5 — DO Facets SQLite-per-DO vs mnemo DuckDB-per-agent (substrate-level)
+
+[Cloudflare Durable Object Facets](https://blog.cloudflare.com/durable-object-facets-dynamic-workers/) (open beta, 2026-04-30) is the closest substrate analogue to mnemo today: each Facet is dynamically loaded with a private SQLite database, the same per-tenant-embedded shape mnemo runs on DuckDB. The comparison sharpens to four concrete axes:
+
+| Axis | DO Facets SQLite-per-DO | mnemo DuckDB-per-agent |
+|---|---|---|
+| Per-tenant footprint | One SQLite file per Facet (managed by Cloudflare) | One `*.mnemo.db` DuckDB file per agent (operator-held) |
+| Cold-start | Facet instantiation is dynamic (paper claim: "load and instantiate dynamically") — TBD measured | DuckDB `Connection::open` against a fresh file: ~1-3ms locally; pre-warmed in mnemo's MCP server | 
+| Persistence boundary | Cloudflare-account-bound — survives Worker version upgrades, but exit requires Cloudflare's export tooling | Operator-held DuckDB file — copy-the-file is the entire export, no platform-specific tooling required |
+| Audit-replay shape | Workers Audit Log + DO event metadata; cryptographic receipt only if the operator builds it | First-class: every `recall(..., with_provenance=true)` returns an HMAC-SHA256 receipt verifiable with `mnemo.provenance.verify_read_provenance` purely offline |
+
+Bench numbers: TBD pending the `mnemo-bench-cf` crate (parked for v0.4.3). The crate will run identical workload against both substrates and quantify cold-start + per-tenant footprint + cross-Facet leak probe + sovereignty round-trip. This row's contract is what the bench harness produces against.
 
 ### S2 — FORGET residual probe
 

--- a/docs/compat/version-skew-matrix.md
+++ b/docs/compat/version-skew-matrix.md
@@ -1,17 +1,25 @@
 # Mnemo Version Skew Matrix
 
-> Updated 2026-05-03 for the v0.4.2 cut.
+> Updated 2026-05-04 for the v0.4.3 cut.
 
 The matrix below pins which downstream and upstream versions are tested
 together for each `mnemo` workspace release. Bumping any cell requires a
 new workspace cut (the Cargo `workspace.package.version` is the
-source-of-truth — see [U1 in CHANGELOG](../../CHANGELOG.md)).
+source-of-truth — see [CHANGELOG](../../CHANGELOG.md)).
 
-## Current
+## Server-side (Rust workspace + storage)
 
-| `mnemo` (Cargo workspace) | `rmcp` | `tantivy` | `usearch` | `pgvector` | `sqlx` | Python SDK (`mnemo-db`) | TypeScript SDK (`@mndfreek/mnemo-sdk`) | Go SDK (`mnemo.Version`) |
-|---|---|---|---|---|---|---|---|---|
-| **0.4.2** (2026-05-03) | 1.3 | 0.26 | 2.21 | 0.8.2 | 0.8 | 0.4.2 | 0.4.2 | 0.4.2 |
+| `mnemo` (Cargo workspace) | `rmcp` | `tantivy` | `usearch` | `duckdb` | `pgvector` | `sqlx` | Cloudflare substrate ³ |
+|---|---|---|---|---|---|---|---|
+| **0.4.3** (planned) | 1.3 | 0.26 | 2.21 | **1.10502.0** ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize **+** DO Facets SQLite ³ |
+| 0.4.2 (2026-05-03) | 1.3 | 0.26 | 2.21 | 1.4 | 0.8.2 | 0.8 | Workers KV+Vectorize (anchor only) |
+
+## SDK side (Python / TypeScript / Go + MCP SDKs)
+
+| `mnemo` | Python SDK (`mnemo-db`) | TS SDK (`@mndfreek/mnemo-sdk`) | Go SDK (`mnemo.Version`) | `mcp-python` ⁵ | `mcp-go` ⁵ | `mcp-ruby` ⁵ | `mcp-csharp` ⁵ |
+|---|---|---|---|---|---|---|---|
+| **0.4.3** (planned) | 0.4.3 | 0.4.3 | 0.4.3 | 1.13.x (2026-05-01) | 0.31.x (2026-05-01) | 0.5.x (2026-05-02) | 0.4.x (2026-05-02) |
+| 0.4.2 (2026-05-03) | 0.4.2 | 0.4.2 | 0.4.2 | 1.12.x | 0.30.x | 0.4.x | 0.3.x |
 
 ## History
 
@@ -31,15 +39,44 @@ source-of-truth — see [U1 in CHANGELOG](../../CHANGELOG.md)).
   release; consumers building against 0.3.x should pin `rmcp = "1.3"`
   to match.
 
+³ **Cloudflare substrate** — `mnemo-bench-cf` (parked for v0.4.3) will
+  baseline mnemo against **two** Cloudflare substrates rather than
+  one: (a) the hosted Agent Memory service (Workers KV + Vectorize)
+  per the 2026-04-30 GA, and (b) the Durable Object Facets open beta
+  (SQLite-per-DO) announced 2026-04-30 — see
+  [`docs/comparisons/cloudflare-agent-memory.md`](../comparisons/cloudflare-agent-memory.md)
+  S1 and S1.5. The "+" notation in the v0.4.3 row signals both
+  substrates are baseline targets, not that mnemo runs on both
+  natively today.
+
+⁴ **DuckDB 1.5.2 file-format breaking change.** v0.4.3 bumps `duckdb`
+  from `1.4` to `1.10502.0` (the upstream calendar-encoded version
+  for DuckDB 1.5.2). On-disk files written by 0.4.3+ are not readable
+  by 0.4.2 binaries — see the v0.4.3 BREAKING note in CHANGELOG for
+  the upgrade procedure.
+
+⁵ **MCP SDK matrix** — these are the **client-side** SDKs from
+  `https://github.com/modelcontextprotocol`, distinct from the
+  server-side `rmcp` Rust crate that mnemo's MCP server is built on.
+  Each SDK consumes the same MCP wire protocol (currently
+  `2024-11-05` with the 2025-11-25 authorization spec layered on
+  top); a SDK-side bump rarely requires a mnemo-side rev unless the
+  spec itself changes. The 2026-05-01 / 2026-05-02 SDK refresh is
+  pure client-side; mnemo's `rmcp = "1.3"` pin is unaffected.
+
 ## How to verify
 
-CI enforces the matrix via two regression tests:
+CI enforces the matrix via three regression tests:
 
 - `crates/mnemo-core/tests/version_metadata.rs` — fails if
   `env!("CARGO_PKG_VERSION")` drifts from the matrix's "Current" row.
 - `python/tests/test_version_alignment.py` — fails if
   `mnemo.__version__` does not match the Cargo workspace version
   parsed at test time.
+- `crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs` (v0.4.3) — fails
+  if this matrix file is missing or loses the `mcp-python` /
+  `mcp-go` / `mcp-ruby` / `mcp-csharp` columns. Catches accidental
+  doc deletion ahead of an SDK-bump release.
 
 The TypeScript SDK's `package.json` `version` and the Go SDK's
 `mnemo.Version` are checked at release time by the GitHub Actions

--- a/docs/spec-drift-2026-05-04.md
+++ b/docs/spec-drift-2026-05-04.md
@@ -1,0 +1,88 @@
+# Spec-drift reconciliation — 2026-05-04
+
+> **Status:** descriptive, not prescriptive. Records a long-standing
+> divergence between an external skill template and this repo's own
+> description so that future operators can stop relitigating it each
+> day and act on the canonical source.
+
+## What's drifting
+
+The daily-opportunity-radar skill template (v4.3) used in mnemo's
+daily product-prompt pipeline asserts that this repo's description
+should read:
+
+> "agent-memory library — semantic + episodic stores, MCP-server
+> interface, LangGraph adapter, Cloudflare Workers template."
+
+The repo's actual description on `main` (verified via
+`https://api.github.com/repos/sattyamjjain/mnemo` 2026-05-04 IST)
+is:
+
+> "MCP-native embedded memory database for AI agents built in Rust.
+> REMEMBER/RECALL/FORGET/SHARE primitives with hybrid vector search,
+> AES-256-GCM encryption, DuckDB/PostgreSQL backends & SDKs for
+> Python, TypeScript and Go."
+
+The 54-task lifetime ledger (2026-04-19 → 2026-05-03) has operated
+against the actual repo description for weeks. This divergence is
+recorded so it doesn't get auto-flagged as "drift" again.
+
+## Which is canonical
+
+**The repo description on `main` is canonical.** Reasons:
+
+1. **Operator policy.** "Ship one row honestly over five rows
+   aspirationally" — the repo description names what mnemo *is*
+   today; the skill template names what mnemo *might one day be*.
+2. **SEO / discovery surface.** The repo description is what GitHub
+   search indexes, what `cargo install mnemo-mcp-server`'s metadata
+   pulls from, and what the v0.4.2 / v0.4.3 release notes route
+   readers to. Rewriting it to match the template would silently
+   degrade those signals.
+3. **Topic ranking.** The repo's GitHub topics today are
+   `ai-agents, ai-memory, duckdb, embeddings, encryption, llm-tools,
+   mcp, memory-management, model-context-protocol, postgresql, rag,
+   rust, semantic-search, vector-database` — these align with the
+   actual description, not the skill-template version.
+
+A future description rewrite is a v0.5.0+ marketing decision, not a
+daily-prompt cleanup. If it happens, this file gets updated; until
+then it stays as is.
+
+## How the skill-template anchors map to this repo
+
+The skill template anchors on four surfaces; here is where each one
+actually lives in the codebase today:
+
+| Skill-template anchor | Where it lives in this repo (2026-05-04) |
+|---|---|
+| **Semantic store** | Vector RRF in [`crates/mnemo-core/src/index/`](../crates/mnemo-core/src/index) (USearch HNSW) + [`crates/mnemo-core/src/search/`](../crates/mnemo-core/src/search) (Tantivy BM25). Hybrid scoring fused via Reciprocal Rank Fusion in the recall path. |
+| **Episodic store** | Append-only event log in `agent_events` table + [`mnemo.replay`](../crates/mnemo-mcp/src/server.rs) MCP tool for reconstructing agent context at any prior point. PostgreSQL backend additionally enforces append-only via a `prevent_event_modification` trigger. |
+| **MCP server interface** | [`crates/mnemo-mcp/`](../crates/mnemo-mcp) (Rust, `rmcp = "1.3"`) + the [`mnemo-mcp-server`](../crates/mnemo-cli) binary (`cargo install mnemo-mcp-server`). 11 tools: `mnemo.{remember,recall,forget,forget_subject,share,checkpoint,branch,merge,replay,delegate,verify}`. |
+| **LangGraph adapter** | `MnemoLangGraphTools` in [`python/mnemo/langgraph_mcp.py`](../python/mnemo/langgraph_mcp.py); Python-side. The Rust-native `mnemo-langgraph` crate (LangGraph 1.2 checkpoint adapter) is parked for the v0.4.3 backlog — see [CHANGELOG](../CHANGELOG.md) carry list. |
+| **Cloudflare Workers template** | v0.4.3 anchor only — the [README's `### Cloudflare Workers deploy template`](../README.md) section + the design note at [`docs/src/integrations/cloudflare-workers-deploy.md`](src/integrations/cloudflare-workers-deploy.md) document the contract. The actual `deploy/cloudflare/` scaffold + the `mnemo-bench-cf` crate are parked for v0.4.3 backlog. |
+
+## Policy going forward
+
+1. **Daily prompts treat the repo description on `main` as the
+   ground truth.** The skill template's description is not consulted
+   for surface-drift checks.
+2. **Surface-drift audits compare the repo description against the
+   actual code in the repo**, not against the skill template.
+3. **A future description rewrite** (e.g. for v0.5.0) requires:
+   - A docs PR updating both this file and the repo description in
+     one shot.
+   - A topics review (the GitHub topics list may need to gain
+     `agent-memory`, `cloudflare-workers`, `langgraph`).
+   - A README-side "Why mnemo" section update so first-impression
+     framing matches.
+4. **Until that PR happens**, contributors landing surface-affecting
+   changes should keep `docs/spec-drift-*.md` in sync if the
+   divergence shifts. See `CONTRIBUTING.md` for the policy link.
+
+## Cross-references
+
+- Repo description (canonical, 2026-05-04): https://api.github.com/repos/sattyamjjain/mnemo
+- v0.4.3 carry list: [CHANGELOG.md](../CHANGELOG.md) `[Unreleased]` section
+- Workers design note: [`docs/src/integrations/cloudflare-workers-deploy.md`](src/integrations/cloudflare-workers-deploy.md)
+- LangGraph adapter (today's Python, tomorrow's Rust): [`python/mnemo/langgraph_mcp.py`](../python/mnemo/langgraph_mcp.py)

--- a/docs/src/integrations/cloudflare-workers-deploy.md
+++ b/docs/src/integrations/cloudflare-workers-deploy.md
@@ -1,0 +1,79 @@
+# Cloudflare Workers deploy template — design note
+
+> **Status:** *design anchor*, not a shipped template. The `deploy/cloudflare/` scaffold is parked for v0.4.3 follow-up. This page is the contract that scaffold will produce against.
+>
+> **Primary anchor:** [Cloudflare Durable Object Facets — open beta (2026-04-30)](https://blog.cloudflare.com/durable-object-facets-dynamic-workers/).
+
+## Why Workers, why now
+
+Cloudflare Durable Object Facets shipped as open beta on 2026-04-30. Each Facet "load[s] and instantiate[s] a Durable Object class dynamically, while providing it with a SQLite database to use for storage" (per the announcement). That is exactly the per-tenant embedded-substrate shape mnemo already runs on DuckDB-per-agent — making Workers the natural managed runtime for an mnemo MCP server when an operator wants Cloudflare's edge boundary instead of running their own box.
+
+The trade-off is honest: mnemo on Workers stops being a Rust-native binary and starts crossing the JS boundary (the Worker entrypoint is JS; the DO class is JS; mnemo's Rust core has to be exposed via WASM or via an HTTP shim). The bench numbers from `mnemo-bench-cf` (parked for v0.4.3) will quantify the gap. This page is the design contract those numbers run against.
+
+## Intended layout (single Worker, one DO Facet per tenant)
+
+```toml
+# wrangler.toml (sketch — not yet shipped under deploy/cloudflare/)
+name = "mnemo-mcp-worker"
+main = "dist/worker.js"
+compatibility_date = "2026-05-04"
+
+[[durable_objects.bindings]]
+name = "MNEMO_TENANT"
+class_name = "MnemoTenantFacet"
+# DO Facet — each instance gets its own SQLite-backed storage.
+# One Facet ≈ one mnemo agent_id namespace.
+
+[vars]
+# HMAC keystore is operator-held — never lives in vars or secrets that
+# the Cloudflare account boundary can read. See "Operator-held material"
+# below.
+MNEMO_DEFAULT_AGENT = "claude-prod"
+```
+
+## What stays Rust-native vs. crosses the JS boundary
+
+| Surface | Where it lives | Notes |
+|---|---|---|
+| MCP transport (stdio → HTTP) | JS Worker | Worker entrypoint converts incoming HTTP to MCP JSON-RPC framing |
+| Tool-router (`tools/list`, `tools/call`) | JS Worker | Pure routing; no compute — can stay JS |
+| Recall + Remember + Forget query engine | Rust core (WASM) | Compiled with `wasm32-unknown-unknown`; today this requires a USearch-WASM port that doesn't exist yet — see "Open questions" |
+| HMAC chain + provenance signing | Rust core (WASM) | Pure compute, no I/O; clean WASM boundary |
+| Storage (DuckDB → SQLite) | JS Worker (DO Facet API) | DuckDB doesn't run in Workers; mnemo's storage layer would route to the Facet's SQLite via a `StorageBackend` trait impl |
+| Vector index (USearch) | Rust WASM, Facet-stored | Today USearch is C++ via `usearch` crate — the WASM build is **the load-bearing missing piece** for v0.4.3 |
+| Full-text (Tantivy) | Rust WASM | Tantivy compiles to WASM; should be straightforward |
+
+## File-format compatibility
+
+mnemo writes DuckDB; the Workers Facet exposes SQLite. They are **not** wire-compatible. The MCP server contract (REMEMBER / RECALL / FORGET / SHARE) is preserved, but **a memory written to a Workers-backed mnemo cannot be read by a self-hosted DuckDB-backed mnemo without an explicit `mnemo export` → `mnemo import` round-trip**. Document this loudly in the eventual scaffold's README.
+
+`mnemo-bench-cf` will quantify whether the SQLite-per-DO recall p50 is within the 2× envelope of DuckDB-per-agent on the same workload. If not, the scaffold ships with explicit "do not use for latency-sensitive workloads" warnings.
+
+## Operator-held material — what NEVER goes into Cloudflare
+
+- **HMAC keystore** (the `keystore_path` in `examples/mcp-server/manifest.toml`). The provenance receipt's whole point is that it's verifiable offline by an auditor who does not have a Cloudflare account. If the keystore lives in Workers Secrets, the receipt's audit value collapses — Cloudflare can rotate or read the key. The keystore MUST stay on operator-held infrastructure (a separate signing service the Worker calls via mTLS, or pre-signed receipts uploaded by an operator-side batch job).
+- **Audit log destination** — the `audit_log_path` should write to operator-held R2 / S3 / GCS, not to Workers Logs (which expire on Cloudflare's cadence and aren't HMAC-chained).
+
+## What `mnemo-bench-cf` must measure
+
+Once the scaffold lands, the bench crate (parked v0.4.3) must produce numbers for:
+
+1. **Cold-start latency** — first recall against a freshly-instantiated Facet vs first recall against a freshly-opened DuckDB.
+2. **Per-tenant footprint** — disk + memory at 10k / 100k / 1M memories.
+3. **Cross-Facet leak probe** — the same probe `mnemo-bench-cf` runs against KV+Vectorize: does Facet A's vector index ever surface a hit from Facet B's writes? Workers' isolation guarantees say "no", but the harness measures.
+4. **Cross-engine round-trip** — write through the Worker, export, re-import to self-hosted DuckDB; does `mnemo verify` re-confirm the chain?
+5. **Sovereignty round-trip** — operator exits Cloudflare; does the Facet's SQLite export carry the HMAC chain into a fresh self-hosted instance with `mnemo verify` still passing?
+
+These are the rows that today sit as `TBD (v0.4.3 bench)` in [`docs/comparisons/cloudflare-agent-memory.md`](../../comparisons/cloudflare-agent-memory.md).
+
+## Open questions (parked for v0.4.3 owner-of-record)
+
+1. **USearch on WASM.** Today no published USearch WASM build. Either (a) port the HNSW step to a pure-Rust crate that compiles to WASM, (b) ship without ANN on Workers and let the bench show what BM25-only recall costs, or (c) call back to a Rust-native sidecar service for vector search. The scaffold owner picks one.
+2. **Tantivy on WASM.** Should compile, but compile time + bundle size matter. Measure before committing.
+3. **DuckDB-on-WASM (`@duckdb/duckdb-wasm`).** An alternative to "Rust core writes to Facet SQLite via a `StorageBackend` impl" — the Worker could host a DuckDB-WASM instance per tenant and persist its file to the Facet's SQLite blob storage. Higher perf parity, but two storage engines and a WASM-on-WASM stack. Trade-off worth measuring.
+
+## Cross-references
+
+- Substrate-level comparison: [`docs/comparisons/cloudflare-agent-memory.md`](../../comparisons/cloudflare-agent-memory.md) — the S1.5 row tracks the DO Facets SQLite vs DuckDB substrate axis.
+- Comparable embedded-memory pitch in README: see the [`## Why mnemo when Cloudflare Agent Memory exists?`](../../../README.md#why-mnemo-when-cloudflare-agent-memory-exists) section, which already concedes edge-recall p50.
+- v0.4.3 carry list: [`CHANGELOG.md`](../../../CHANGELOG.md) — `mnemo-bench-cf` is on the v0.4.3 backlog with the dependency note attached.

--- a/docs/src/integrations/mcp-server.md
+++ b/docs/src/integrations/mcp-server.md
@@ -179,3 +179,25 @@ and the three integration tests under
 
 For the threat model and the full design notes, see the rationale at
 the top of `crates/mnemo-cli/src/safe_spawn.rs`.
+
+## Compatibility note (v0.4.3 — U1)
+
+The MCP wire-protocol version mnemo's server speaks (`2024-11-05`,
+with the [2025-11-25 authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+layered on top) is **independent** of the client SDK version your
+agent uses. SDK refreshes are common and don't require a mnemo-side
+rev unless the spec itself moves.
+
+The current [version-skew matrix](../../../docs/compat/version-skew-matrix.md)
+tracks tested combinations of the four official client SDKs:
+
+- `mcp-python` (refreshed 2026-05-01)
+- `mcp-go` (refreshed 2026-05-01)
+- `mcp-ruby` (refreshed 2026-05-02)
+- `mcp-csharp` (refreshed 2026-05-02)
+
+If your agent hits an SDK-side incompatibility, consult the matrix
+first — most issues land on a row that documents which mnemo cut
+shipped against that SDK pair. The matrix is enforced in CI by
+`crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs`, so the doc itself
+cannot silently disappear ahead of an SDK-bump release.

--- a/python/mnemo/__init__.py
+++ b/python/mnemo/__init__.py
@@ -12,7 +12,7 @@ Example::
     memories = client.recall("user preferences")
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__: list[str] = []
 
 # The native PyO3 extension is optional at import time — users who only need

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 # the PyPI distribution name moves. Users do `pip install mnemo-db`
 # then `from mnemo import MnemoClient`.
 name = "mnemo-db"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP-native memory database for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/tests/test_version_alignment.py
+++ b/python/tests/test_version_alignment.py
@@ -61,6 +61,6 @@ def test_python_sdk_version_matches_pyproject() -> None:
     )
 
 
-def test_v0_4_2_pinned() -> None:
+def test_v0_4_3_pinned() -> None:
     """Sanity-check this exact release. Bump alongside CHANGELOG."""
-    assert mnemo.__version__ == "0.4.2"
+    assert mnemo.__version__ == "0.4.3"

--- a/sdks/go/mnemo.go
+++ b/sdks/go/mnemo.go
@@ -1,7 +1,7 @@
 // Package mnemo is the Go SDK for Mnemo — MCP-native memory database for
 // AI agents.
 //
-// Package version: 0.4.2
+// Package version: 0.4.3
 package mnemo
 
 import (
@@ -15,7 +15,7 @@ import (
 
 // Version is the SDK version. Kept in lockstep with the Cargo workspace
 // `workspace.package.version` and `python/pyproject.toml` `version`.
-const Version = "0.4.2"
+const Version = "0.4.3"
 
 // ClientOptions configures the Mnemo MCP client.
 type ClientOptions struct {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mndfreek/mnemo-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "TypeScript SDK for Mnemo — MCP-native memory database for AI agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
v0.4.3 cut. Three S-effort surfaces from the 2026-05-04 daily prompt + the load-bearing duckdb 1.4 → 1.5.2 bump that has been gated for two release cycles. Closes [#41](https://github.com/sattyamjjain/mnemo/issues/41) Step 1.

## Why `!`

The duckdb bump is a persisted-state breaking change. See CHANGELOG `[0.4.3]` §⚠️ for the four-step operator upgrade procedure. Fresh DBs are unaffected.

## What's new in this PR

### A1 — Cloudflare Workers / DO Facets deploy template anchor

Net-new market trigger: [Cloudflare Durable Object Facets open beta](https://blog.cloudflare.com/durable-object-facets-dynamic-workers/) (2026-04-30). Each Facet loads a Durable Object class dynamically with its own SQLite database — the closest substrate analogue to mnemo's DuckDB-per-agent shape.

- README `### Cloudflare Workers deploy template` subsection under Deployment, citing DO Facets as the substrate anchor for the v0.4.3 `mnemo-bench-cf` crate (parked).
- New `docs/src/integrations/cloudflare-workers-deploy.md` design note covering Rust↔WASM↔DO-Facet boundaries, file-format compatibility (DuckDB ↔ SQLite is **not** wire-compatible), the operator-held HMAC keystore requirement, and open questions (USearch-on-WASM, Tantivy-on-WASM, DuckDB-on-WASM trade-offs).
- `docs/comparisons/cloudflare-agent-memory.md` gains a concrete S1.5 scenario block (per-tenant footprint, cold-start, persistence boundary, audit-replay shape) replacing yesterday's empty-bench placeholders.
- Two new tests: extended marketing-phrase banlist (`tests/readme_no_marketing_phrases.rs` adds `viral`, `game-changing`, `revolutionary`, etc.) and `tests/readme_workers_template_link.rs` (anchor-link survival test).

### U1 — Skew matrix MCP SDK columns + Cloudflare-substrate annotation

The 2026-05-01 / 05-02 client-SDK refresh (Python + Go on 05-01, Ruby + C# on 05-02 per [github.com/modelcontextprotocol](https://github.com/modelcontextprotocol)) landed without forcing a mnemo-side rev — the wire protocol stays at `2024-11-05` with the [2025-11-25 authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) layered on top. Tracking it in the matrix avoids future SDK churn surprises.

- `docs/compat/version-skew-matrix.md` splits server-side and SDK-side rows; new `mcp-python` / `mcp-go` / `mcp-ruby` / `mcp-csharp` columns; v0.4.3 row gains a Cloudflare-substrate annotation listing **both** Workers KV+Vectorize and DO Facets SQLite as `mnemo-bench-cf` baseline targets.
- `docs/src/integrations/mcp-server.md` gains a "Compatibility note" linking to the matrix for SDK-skew triage.
- New regression test `crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs` fails if the doc is missing or loses any of the four `mcp-*` column headers.

### U2 — Spec-drift reconciliation

The daily-product-prompt skill template's anchored repo description has long-standing drifted from the actual `main` description. Rather than relitigate this each day, write down which is canonical (the repo on `main`) and where the skill template's surface anchors actually live in the codebase.

- New `docs/spec-drift-2026-05-04.md` declares the repo description canonical and maps the skill-template anchors (semantic store, episodic store, MCP server, LangGraph adapter, Workers template) to actual repo locations.
- `CONTRIBUTING.md` gains a "Spec-drift policy" subsection linking to the doc.

### Includes — duckdb 1.4 → 1.5.2 + idempotent migrations

(Originally the standalone PR target; folded into this v0.4.3 cut so the breaking change ships with the release notes documenting the upgrade.)

- `workspace.dependencies.duckdb` 1.4 → 1.10502.0 (calendar-encoded for DuckDB 1.5.2 — see [duckdb-rs releases](https://github.com/duckdb/duckdb-rs/releases)).
- New `apply_alters_idempotent` in `crates/mnemo-core/src/storage/migrations.rs` introspects `information_schema.columns` and only emits ALTER when the column is actually missing. The previous swallow-the-error pattern broke under DuckDB 1.5+'s tightened transaction-abort semantics. **Side benefit:** also resolves the pre-existing Ubuntu DuckDB extension race that was admin-merged through every prior release.

## Version metadata bumped

| Surface | From | To |
|---|---|---|
| `Cargo.toml workspace.package.version` | 0.4.2 | **0.4.3** |
| Internal-crate version pins | 0.4.2 | **0.4.3** |
| `python/pyproject.toml version` | 0.4.2 | **0.4.3** |
| `python/mnemo/__init__.py __version__` | 0.4.2 | **0.4.3** |
| `sdks/typescript/package.json version` | 0.4.2 | **0.4.3** |
| `sdks/go/mnemo.go Version` | 0.4.2 | **0.4.3** |

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --workspace --exclude mnemo-python -- -D warnings` clean
- [x] `cargo test --workspace --exclude mnemo-python --no-fail-fast` — **341 passed**, 0 failed, 5 ignored (was 337 on v0.4.2; +4 from new tests)
- [x] All 17 crates check clean against duckdb 1.10502.0
- [x] Verification trace from yesterday's v0.4.2 publish recorded in CHANGELOG

## v0.4.2 verification trace (recorded in CHANGELOG)

- Cargo.toml workspace.package.version = `"0.4.2"` on `main` ✓
- README role-filter section live (v0.4.2 A1) ✓
- README Cloudflare differentiation H2 live (v0.4.2 U2) ✓
- `tests/readme_no_marketing_phrases.rs` green on `main` ✓
- All 17 crates published at `0.4.2` on crates.io ✓
- `mnemo-db@0.4.2` on PyPI ✓
- `@mndfreek/mnemo-sdk@0.4.2` on npm ✓

## Sources

- https://blog.cloudflare.com/durable-object-facets-dynamic-workers/ (DO Facets open beta, 2026-04-30)
- https://github.com/modelcontextprotocol (MCP client SDK 2026-05-01 / 05-02 refresh)
- https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization (MCP authorization spec)
- https://github.com/duckdb/duckdb-rs/releases (duckdb-rs calendar versioning)
- https://duckdb.org/2026/04/13/announcing-duckdb-152 (DuckDB 1.5.2 release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)