### PR TITLE
docs(v0.4.4): cloudflare project think anchor (project-think 2026-05-04), v0.4.3 verification-trace correction, publish-job status doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to Mnemo are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **A1 (v0.4.4) — Cloudflare Project Think positioning anchor.**
+  README `### Project Think — loop vs. ledger` sub-section inside the
+  existing "Why mnemo when Cloudflare Agent Memory exists?" H2,
+  citing the [Project Think announcement](https://blog.cloudflare.com/project-think/)
+  (2026-05-04, 1 day old at land-time). New companion comparison doc
+  [`docs/comparisons/cloudflare-project-think.md`](docs/comparisons/cloudflare-project-think.md)
+  treating Project Think as the *runtime layer* and mnemo as the
+  *audit-ledger layer* — explicitly **complementary, not substitute**
+  surfaces. The bench harness for *Cloudflare Agent Memory vs mnemo*
+  does NOT re-run for Project Think because the answer is layering,
+  not benchmarking. [`docs/src/integrations/cloudflare-workers-deploy.md`](docs/src/integrations/cloudflare-workers-deploy.md)
+  gains a `## Runtime layer (Project Think)` sub-section linking to
+  the new comparison doc. Two new tests: extended marketing-phrase
+  banlist (`competes with Cloudflare`, `replaces Project Think`,
+  `Project Think killer`, `Workers killer`) and
+  `tests/readme_project_think_link.rs` (primary-source + heading +
+  comparison-doc-link survival).
+
+### Changed
+
+- **U1 (v0.4.4) — Sierra $950M raise applied-agent-layer evidence
+  paragraph in [`docs/comparisons/cloudflare-agent-memory.md`](docs/comparisons/cloudflare-agent-memory.md).**
+  One-paragraph *market-evidence, not feature-claim* note citing
+  Sierra's 2026-05-04 raise as concrete evidence the applied-agent
+  layer is well-funded enough to demand the offline-auditable memory
+  substrate mnemo offers.
+- **U1 — corrected v0.4.3 verification trace.** The `## [0.4.3] -
+  2026-05-04` block's original `### Verification trace (2026-05-04)`
+  sub-block was authored before the version-flip commit landed in
+  the same PR — it asserts `Cargo.toml workspace.package.version =
+  "0.4.2"` while the live raw fetch shows `"0.4.3"`. New
+  `### Verification trace (2026-05-05)` sub-block records the
+  corrected state with all artifact-registry checks green; the
+  original trace stays in place as audit history of how the
+  inconsistency arose.
+- **U1 (v0.4.4) — spec-drift reconciliation footer.**
+  [`docs/spec-drift-2026-05-04.md`](docs/spec-drift-2026-05-04.md)
+  gains a `## 2026-05-05 stable-divergence confirmation` footer
+  recording today's check: repo description on `main` unchanged, 14
+  topics unchanged, Phase 6 skill template still anchors the older
+  description — **stable divergence the operator has accepted, not
+  a regression to flap on**.
+
+### Documentation
+
+- **U2 (v0.4.4) — v0.4.3 publish-status doc.** New
+  [`docs/release/v0.4.3-publish-status.md`](docs/release/v0.4.3-publish-status.md)
+  records: cargo-publish job ID + `success` conclusion + 17/17 crates
+  at `0.4.3` on crates.io with published-at timestamps; PyPI
+  `mnemo-db@0.4.3` live; npm `@mndfreek/mnemo-sdk@0.4.3` live. The
+  v0.4.3 publish completed cleanly under the bumped 300-min job
+  timeout — no resume-dance required.
+
+### Tests
+
+- `tests/changelog_has_unreleased_section.rs` — fails the build if
+  `CHANGELOG.md` ever loses its `## [Unreleased]` heading.
+- `tests/release_status_doc_present.rs` — fails the build if
+  `docs/release/v0.4.3-publish-status.md` is missing the canonical
+  `Cargo workspace v0.4.3 publish status` header. Cheap drift guard
+  for the release-day audit habit.
+
 ## [0.4.3] - 2026-05-04
 
 Substrate-anchor release. Three S-effort surfaces: a Cloudflare
@@ -66,6 +132,12 @@ the pre-existing Ubuntu DuckDB extension race.
 
 ### Verification trace (2026-05-04)
 
+> ⚠️ **This trace was authored before the version-flip commit landed
+> in the same PR.** It asserts `Cargo.toml = "0.4.2"` while the live
+> raw fetch shows `"0.4.3"`. The version flip was the *intent* of the
+> PR, not a regression. See the corrected `### Verification trace
+> (2026-05-05)` sub-block below for the post-merge state.
+
 - `Cargo.toml` workspace.package.version = `"0.4.2"` on `main` ✓
 - README role-filter section live (v0.4.2 A1) ✓
 - README Cloudflare differentiation H2 live (v0.4.2 U2) ✓
@@ -73,6 +145,32 @@ the pre-existing Ubuntu DuckDB extension race.
 - All 17 crates published at `0.4.2` on crates.io ✓
 - `mnemo-db@0.4.2` on PyPI ✓
 - `@mndfreek/mnemo-sdk@0.4.2` on npm ✓
+
+### Verification trace (2026-05-05) — corrected post-merge state
+
+Recorded one day after the v0.4.3 cut to capture the published-state
+ground truth. Origin of the correction: today's U1 row.
+
+- `Cargo.toml` workspace.package.version = `"0.4.3"` on `main` ✓
+- `duckdb = "=1.10502.0"` workspace pin live ✓
+- `apply_alters_idempotent` migration runner live in
+  `crates/mnemo-core/src/storage/migrations.rs` ✓
+- README "Cloudflare Workers deploy template" sub-section live
+  (v0.4.3 A1) ✓
+- `tests/readme_workers_template_link.rs` green on `main` ✓
+- `tests/readme_no_marketing_phrases.rs` extended banlist green on
+  `main` ✓
+- `crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs` green on
+  `main` ✓
+- `docs/spec-drift-2026-05-04.md` live (v0.4.3 U2) ✓
+- All 17 crates published at `0.4.3` on crates.io ✓ (cargo-publish
+  job completed `success` under the bumped 300-min cap — see
+  [`docs/release/v0.4.3-publish-status.md`](docs/release/v0.4.3-publish-status.md))
+- `mnemo-db@0.4.3` on PyPI ✓
+- `@mndfreek/mnemo-sdk@0.4.3` on npm ✓
+- 4 dependabot bumps merged after v0.4.3 cut: `actions/setup-node`
+  v4→v6 (#69), `actions/download-artifact` v7→v8 (#70), `toml`
+  0.9→1.1 (#71), `tokenizers` 0.22→0.23 (#72) ✓
 
 ### ⚠️  Breaking — persisted state upgrade required
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,25 @@ documents the differentiation scenario list with empty-bench
 placeholders so the comparison's contract is explicit before the
 numbers land.
 
+### Project Think — loop vs. ledger
+
+Cloudflare extended this story on [2026-05-04](https://blog.cloudflare.com/project-think/)
+with **Project Think**, a runtime story for AI agents built on Workers
++ DO Facets — the *durable agentic loop* itself. Project Think is
+upstream of mnemo's surface: it owns where the agent runs and how the
+loop survives a Worker restart. mnemo owns whether the writes that loop
+emits are cryptographically chained, replayable months later, and
+inspectable without a Cloudflare account.
+
+These are **complementary, not substitute, surfaces.** An operator can
+run their durable loop on Project Think + DO Facets and chain every
+memory write into mnemo's HMAC ledger; the bench crate that compares
+*Cloudflare Agent Memory vs mnemo as a memory store* does not redo
+itself for *Project Think as a runtime vs mnemo as a memory ledger* —
+the latter is a layering question, not a benchmark. See
+[`docs/comparisons/cloudflare-project-think.md`](docs/comparisons/cloudflare-project-think.md)
+for the full layering table and where each side wins.
+
 ## Examples
 
 The `examples/` directory contains working integration examples for all major agent frameworks:

--- a/crates/mnemo-cli/tests/changelog_has_unreleased_section.rs
+++ b/crates/mnemo-cli/tests/changelog_has_unreleased_section.rs
@@ -1,0 +1,47 @@
+//! v0.4.4 (U1) — CHANGELOG.md must always carry a `## [Unreleased]`
+//! heading. Cheap drift guard against accidental deletion when a
+//! release-day commit forgets to re-open the next cycle's section.
+//!
+//! When a version cuts (e.g. v0.4.4), this test continues to pass
+//! because the cut workflow renames `## [Unreleased]` to `## [0.4.4]`
+//! and writes a fresh `## [Unreleased]` above it. If that pattern is
+//! broken, this test catches it before the release lands.
+
+use std::path::Path;
+
+#[test]
+fn changelog_has_unreleased_section() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("CHANGELOG.md");
+    let body =
+        std::fs::read_to_string(&path).expect("CHANGELOG.md must be readable from repo root");
+    assert!(
+        body.contains("## [Unreleased]"),
+        "CHANGELOG.md must carry a `## [Unreleased]` heading at all times. \
+         When cutting a release, rename the previous `## [Unreleased]` to \
+         `## [<version>]` and open a fresh `## [Unreleased]` above it."
+    );
+}
+
+#[test]
+fn changelog_unreleased_appears_above_latest_release_heading() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("CHANGELOG.md");
+    let body = std::fs::read_to_string(&path).expect("CHANGELOG.md readable");
+    let unreleased_idx = body
+        .find("## [Unreleased]")
+        .expect("[Unreleased] heading required");
+    // Find the first dated release heading (`## [<X.Y.Z>] - <YYYY-MM-DD>`).
+    let release_idx = body
+        .find("## [0.")
+        .expect("at least one dated release heading required");
+    assert!(
+        unreleased_idx < release_idx,
+        "`## [Unreleased]` must appear above the latest dated release heading; \
+         CHANGELOG.md ordering is reversed."
+    );
+}

--- a/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
+++ b/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
@@ -32,6 +32,13 @@ const BANNED_PHRASES: &[&str] = &[
     "wild",
     "mind-blowing",
     "mind blowing",
+    // v0.4.4 (A1) — Project Think positioning. The new section is
+    // explicit about loop-vs-ledger being COMPLEMENTARY, not
+    // substitute. Block any drift into adversarial framing:
+    "competes with Cloudflare",
+    "replaces Project Think",
+    "Project Think killer",
+    "Workers killer",
 ];
 
 #[test]

--- a/crates/mnemo-cli/tests/readme_project_think_link.rs
+++ b/crates/mnemo-cli/tests/readme_project_think_link.rs
@@ -1,0 +1,43 @@
+//! v0.4.4 (A1) — README's Cloudflare H2 must keep its primary-source
+//! anchor to the 2026-05-04 Project Think announcement and the
+//! companion comparison doc. A future README rewrite that drops either
+//! anchor will fail this test before it can land.
+
+use std::path::Path;
+
+const PRIMARY_SOURCE: &str = "https://blog.cloudflare.com/project-think/";
+const SUBSECTION_HEADING: &str = "Project Think — loop vs. ledger";
+const COMPARISON_DOC_PATH: &str = "docs/comparisons/cloudflare-project-think.md";
+
+fn read_readme() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("README.md");
+    std::fs::read_to_string(&path).expect("README.md must be readable from repo root")
+}
+
+#[test]
+fn project_think_paragraph_keeps_primary_source_link() {
+    let body = read_readme();
+    assert!(
+        body.contains(PRIMARY_SOURCE),
+        "README.md must keep the Project Think primary-source URL ({PRIMARY_SOURCE}). \
+         The Cloudflare H2 section without the Project Think anchor would be a \
+         marketing claim, not a technical pointer."
+    );
+}
+
+#[test]
+fn project_think_subsection_and_comparison_doc_link_present() {
+    let body = read_readme();
+    assert!(
+        body.contains(SUBSECTION_HEADING),
+        "README.md must keep the `### {SUBSECTION_HEADING}` subsection (v0.4.4 A1)."
+    );
+    assert!(
+        body.contains(COMPARISON_DOC_PATH),
+        "README.md must keep its link to {COMPARISON_DOC_PATH} so readers can reach \
+         the layering rationale from the H2 section."
+    );
+}

--- a/crates/mnemo-cli/tests/release_status_doc_present.rs
+++ b/crates/mnemo-cli/tests/release_status_doc_present.rs
@@ -1,0 +1,61 @@
+//! v0.4.4 (U2) — `docs/release/v0.4.3-publish-status.md` survival test.
+//!
+//! Cheap drift guard for the release-day audit habit: the
+//! per-version publish-status doc must exist and carry the canonical
+//! header so a future release-day tooling pass can locate the audit
+//! ledger by string match instead of fuzzy filename guessing.
+
+use std::path::Path;
+
+const DOC_PATH: &str = "docs/release/v0.4.3-publish-status.md";
+const REQUIRED_HEADER: &str = "Cargo workspace v0.4.3 publish status";
+
+#[test]
+fn release_status_doc_exists_and_has_canonical_header() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(DOC_PATH);
+    let body = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!("{DOC_PATH} must exist as the v0.4.3 publish-status audit ledger: {e}");
+    });
+    assert!(
+        body.contains(REQUIRED_HEADER),
+        "{DOC_PATH} must carry the canonical `# {REQUIRED_HEADER}` header so \
+         release-day tooling can locate the audit ledger by string match."
+    );
+}
+
+#[test]
+fn release_status_doc_records_all_seventeen_crates() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(DOC_PATH);
+    let body = std::fs::read_to_string(&path).expect("publish-status doc readable");
+    for crate_name in [
+        "mnemo-core",
+        "mnemo-graph",
+        "mnemo-mcp",
+        "mnemo-postgres",
+        "mnemo-rest",
+        "mnemo-admin",
+        "mnemo-pgwire",
+        "mnemo-grpc",
+        "mnemo-compliance",
+        "mnemo-letta",
+        "mnemo-mesh",
+        "mnemo-codemode",
+        "mnemo-deal",
+        "mnemo-md-sync",
+        "mnemo-cma",
+        "mnemo-baseline",
+        "mnemo-mcp-server",
+    ] {
+        assert!(
+            body.contains(crate_name),
+            "publish-status doc must list crate `{crate_name}` — drift would leave \
+             the audit ledger incomplete."
+        );
+    }
+}

--- a/docs/comparisons/cloudflare-agent-memory.md
+++ b/docs/comparisons/cloudflare-agent-memory.md
@@ -132,6 +132,30 @@ producing a tamper-evident audit row?
 - The threat model includes **DPDPA / GDPR subject erasure with audit
   trail preservation** (`forget_subject --strategy redact`).
 
+## Applied-agent-layer market evidence (2026-05-05)
+
+> *Market evidence, not a feature claim.* The point of this section is
+> to record that the demand-side substrate this comparison serves is
+> well-funded enough to require a real auditable-memory layer — not to
+> imply mnemo is endorsed by, used by, or competitive with any specific
+> applied-agent vendor.
+
+[Sierra raised $950M on 2026-05-04](https://www.sierra.ai/) at a
+$10B valuation, the largest applied-agent-layer round disclosed to
+date. Sierra builds tenant-scoped customer-experience agents — the
+exact shape of deployment that needs (a) per-tenant memory isolation,
+(b) HMAC-chained audit trail durability, and (c) offline replay for
+incident review. Mnemo's positioning here is unchanged: an
+applied-agent-layer vendor running on Cloudflare's edge, AWS, or any
+combination still needs a memory ledger whose audit contract survives
+outside any one cloud's account boundary. This raise is read as
+*the demand-side substrate being well-funded*, not as a vendor
+endorsement.
+
+The same axis that this comparison's S3 (chain audit replay) and S5
+(sovereignty round-trip) rows test is what an applied-agent-layer
+deployment of this scale ultimately reaches for.
+
 ## v0.4.3 plan
 
 The `mnemo-bench-cf` crate (deferred from the 2026-05-02 prompt) will:

--- a/docs/comparisons/cloudflare-project-think.md
+++ b/docs/comparisons/cloudflare-project-think.md
@@ -1,0 +1,133 @@
+# mnemo vs Cloudflare Project Think — runtime layer vs audit-ledger layer
+
+> Living doc, last updated 2026-05-05. Companion to
+> [`cloudflare-agent-memory.md`](cloudflare-agent-memory.md) (the *memory
+> store* comparison) and [`../src/integrations/cloudflare-workers-deploy.md`](../src/integrations/cloudflare-workers-deploy.md)
+> (the *deploy template* design note). Where the agent-memory doc asks
+> "should I store agent memory here or there?", this doc asks the more
+> upstream question: "where does the agent loop run, and where does
+> its audit trail live?"
+
+## Why this comparison exists
+
+Cloudflare announced **Project Think** on [2026-05-04](https://blog.cloudflare.com/project-think/),
+positioned as "building the next generation of AI agents on Cloudflare."
+The thesis is a *durable agentic loop* on Workers + DO Facets — a
+runtime that survives Worker restarts, region failovers, and tenant
+isolation boundaries. It is upstream of where mnemo sits.
+
+The temptation is to read Project Think as a competitor. **It isn't.**
+Project Think owns the runtime layer; mnemo owns the audit/replay
+layer. Operators evaluating both have a layering question, not a
+substitution question.
+
+## Honest layering up front
+
+| Layer | What lives there | Who owns it well today |
+|---|---|---|
+| Durable agent loop runtime | Where the agent's tick-by-tick execution survives a process restart | **Project Think** (Cloudflare) — first-class story; mnemo does not compete here |
+| Per-tenant embedded storage substrate | The disk the agent's working memory writes to | **DO Facets SQLite** (Cloudflare) ↔ **DuckDB-per-agent** (mnemo). See `cloudflare-agent-memory.md` S1.5 for the substrate-level comparison |
+| Hosted memory service | Edge-cached recall over a managed vector index | **Cloudflare Agent Memory** (KV+Vectorize). See `cloudflare-agent-memory.md` S1 |
+| Cryptographic audit ledger | HMAC-chained writes + offline-verifiable provenance receipts + point-in-time `as_of` replay | **mnemo** — first-class story; Cloudflare's Workers Audit Log is *not* a chained-receipt substrate |
+
+The honest mnemo positioning: an operator running their durable loop
+on Project Think can **also** chain every memory write into mnemo's
+HMAC ledger. The two are stacked, not exclusive.
+
+## Where each side wins
+
+### Project Think wins
+
+- **Durable execution under Worker churn.** A 14-day agent loop that
+  survives Worker version upgrades, region failovers, and tenant
+  isolation boundaries — Cloudflare's runtime story. mnemo has no
+  equivalent and isn't trying to.
+- **Edge-region tick latency.** The loop ticks where the user is.
+- **Hosted observability of the loop itself.** Cloudflare's tenancy
+  and lifecycle metadata around the loop are first-class.
+- **Zero-ops runtime.** No box for the operator to run.
+
+### mnemo wins
+
+- **Offline-verifiable provenance.** Every `recall(..., with_provenance=true)`
+  returns an HMAC-SHA256 receipt verifiable with
+  `mnemo.provenance.verify_read_provenance` purely offline — no
+  Cloudflare account needed, three months later, by an auditor who
+  was not on the original deployment.
+- **Chain replay at point-in-time.** `mnemo replay --as-of <ts>` against
+  the local DB + audit log reconstructs the exact memory the agent
+  saw at any past moment. Cloudflare's Workers Audit Log retention
+  cadence and access tooling do not produce this shape.
+- **Sovereignty round-trip.** Operator exits Cloudflare; the DuckDB
+  file is the entire database; `mnemo verify` runs on any host.
+  Project Think's runtime state is Cloudflare-account-bound.
+- **Cross-engine memory ledger.** A loop running on Project Think can
+  chain into mnemo; a loop running on Temporal can also chain into
+  mnemo; a loop running on AWS Step Functions can also chain into
+  mnemo. mnemo's audit contract is runtime-agnostic by design.
+
+## How they compose
+
+The cleanest stack for an operator who wants both:
+
+1. **Durable loop on Project Think + DO Facets.** Worker entrypoint
+   converts incoming HTTP to MCP JSON-RPC framing; the DO Facet's
+   SQLite stores per-tenant working memory.
+2. **Audit-ledger writes go to operator-held mnemo.** Either via an
+   HTTP shim that the Worker calls on every memory write, or as a
+   batch job at the end of each loop tick. The HMAC keystore stays
+   on operator-held infrastructure (Workers Secrets is *not* the
+   right place — see [`cloudflare-workers-deploy.md`](../src/integrations/cloudflare-workers-deploy.md)
+   §"Operator-held material").
+3. **`mnemo verify`** runs against the chained-write ledger as a
+   separate audit step — no Cloudflare account required.
+
+The bench harness for *Cloudflare Agent Memory vs mnemo as a memory
+store* (parked v0.4.4 backlog `mnemo-bench-cf`) **does not redo itself
+for Project Think.** The latter is a layering question — solved by
+the stacking pattern above — not a benchmark.
+
+## When Cloudflare alone is the right choice
+
+- The compliance posture is *"trust the cloud's audit log"* — Cloudflare's
+  Workers Audit Log is sufficient for the operator's auditors.
+- The agent's durable loop never needs to outlast a Cloudflare account
+  boundary (org change, region migration, vendor exit).
+- The agent's memory is fully ephemeral / per-session — no
+  cross-session reconstruction requirement, no `as_of` replay, no
+  provenance receipt that survives offline.
+
+## When mnemo (stacked under Project Think) is the right choice
+
+- The compliance posture requires offline replay of any agent's
+  decision against an HMAC-signed history.
+- The agent's audit trail must survive any specific cloud's
+  retention cadence — including the cloud's own outages or
+  account-level access changes.
+- The agent's memory is part of a **multi-runtime** strategy (loop
+  on Cloudflare today, loop on Temporal tomorrow, audit on a single
+  operator-held mnemo throughout).
+- The threat model includes DPDPA / GDPR subject erasure with audit
+  trail preservation (`forget_subject --strategy redact` chain
+  preserved).
+
+## v0.4.4+ plan
+
+- The `mnemo-bench-cf` crate (parked) **does not bench Project Think
+  as a runtime** — that's a layering question, not a perf question.
+  The bench targets remain: hosted Agent Memory KV+Vectorize and DO
+  Facets SQLite as memory-store substrates.
+- A future `deploy/cloudflare/` scaffold (parked v0.4.4 backlog) will
+  ship the stacking pattern above as a reference implementation: a
+  Worker + DO Facet running the durable loop, with a `wrangler.toml`
+  binding to an operator-held mnemo audit endpoint.
+- The `cloudflare-workers-deploy.md` design note's "Runtime layer
+  (Project Think)" sub-section links here for the layering rationale.
+
+## Sources
+
+- Cloudflare Project Think announcement — https://blog.cloudflare.com/project-think/ (2026-05-04)
+- Cloudflare Durable Object Facets open beta — https://blog.cloudflare.com/durable-object-facets-dynamic-workers/ (2026-04-30, the storage substrate Project Think builds on)
+- Cloudflare Agents Week wrap — https://www.cloudflare.com/agents-week/updates/ (2026-04-29, broader runtime context)
+- mnemo memory-store comparison: [`cloudflare-agent-memory.md`](cloudflare-agent-memory.md)
+- mnemo deploy-template design: [`../src/integrations/cloudflare-workers-deploy.md`](../src/integrations/cloudflare-workers-deploy.md)

--- a/docs/release/v0.4.3-publish-status.md
+++ b/docs/release/v0.4.3-publish-status.md
@@ -1,0 +1,94 @@
+# Cargo workspace v0.4.3 publish status
+
+> Recorded 2026-05-05 (one day after the cut). All artifact registries
+> green. The bumped 300-min `cargo-publish` job timeout (raised from
+> 180 in the v0.4.3 cut PR) was load-bearing — the actual run took
+> ~253 minutes, which would have been cancelled mid-sequence under
+> the prior cap.
+
+## TL;DR
+
+| Channel | Version | State |
+|---|---|---|
+| Git `main` | `7894a3a` (cut) → `03fff20` (post-dependabot) | ✅ |
+| Tag | `v0.4.3` | ✅ pushed |
+| crates.io | 17/17 crates at `0.4.3` | ✅ |
+| PyPI (`mnemo-db`) | `0.4.3` | ✅ |
+| npm (`@mndfreek/mnemo-sdk`) | `0.4.3` | ✅ |
+
+## cargo-publish job
+
+- **Run:** [25305225245](https://github.com/sattyamjjain/mnemo/actions/runs/25305225245)
+- **Conclusion:** `success`
+- **Started:** 2026-05-04T06:51:29Z (on the v0.4.3 cut commit `7894a3a`)
+- **Ended:** 2026-05-04T11:04:49Z
+- **Duration:** ~253 min (12-min crates.io rate-limit spacing × 17 crates + per-crate compile/upload)
+- **Timeout cap:** 300 min (bumped from 180 in the same PR — see [`.github/workflows/cargo-publish.yml`](../../.github/workflows/cargo-publish.yml) line 90 for the rationale)
+- **Resume runs needed:** **0** — single-shot completion, no `workflow_dispatch` re-trigger required.
+
+The prior v0.4.2 cut had been cancelled at 183 min (10/17 crates done) under the 180-min cap and required a manual resume. The 300-min bump in this PR was specifically calibrated for the 17-crate workspace and held cleanly.
+
+## crates.io publish ledger (17/17)
+
+| Crate | Version | Published-at (UTC) |
+|---|---|---|
+| `mnemo-core` | 0.4.3 | 2026-05-04T06:54:04.185301Z |
+| `mnemo-graph` | 0.4.3 | 2026-05-04T07:07:11.756968Z |
+| `mnemo-mcp` | 0.4.3 | 2026-05-04T07:28:09.594749Z |
+| `mnemo-postgres` | 0.4.3 | 2026-05-04T07:49:12.780110Z |
+| `mnemo-rest` | 0.4.3 | 2026-05-04T08:10:15.646078Z |
+| `mnemo-admin` | 0.4.3 | 2026-05-04T08:22:19.389102Z |
+| `mnemo-pgwire` | 0.4.3 | 2026-05-04T08:34:22.845263Z |
+| `mnemo-grpc` | 0.4.3 | 2026-05-04T08:55:20.090813Z |
+| `mnemo-compliance` | 0.4.3 | 2026-05-04T09:07:28.537308Z |
+| `mnemo-letta` | 0.4.3 | 2026-05-04T09:28:01.737960Z |
+| `mnemo-mesh` | 0.4.3 | 2026-05-04T09:40:05.039770Z |
+| `mnemo-codemode` | 0.4.3 | 2026-05-04T09:52:07.973046Z |
+| `mnemo-deal` | 0.4.3 | 2026-05-04T10:04:11.371773Z |
+| `mnemo-md-sync` | 0.4.3 | 2026-05-04T10:16:14.476177Z |
+| `mnemo-cma` | 0.4.3 | 2026-05-04T10:28:17.862021Z |
+| `mnemo-baseline` | 0.4.3 | 2026-05-04T10:40:20.902605Z |
+| `mnemo-mcp-server` | 0.4.3 | 2026-05-04T10:52:43.480836Z |
+
+The dep-order is the same as `cargo-publish.yml`'s `plan` job emits (mnemo-core first, mnemo-mcp-server last). Each crate's published-at timestamp is fetched from the `crates.io/api/v1/crates/<name>/0.4.3` `version.created_at` field.
+
+## PyPI
+
+- **Distribution:** `mnemo-db`
+- **Version:** `0.4.3`
+- **Published-at:** 2026-05-04T07:11:01.857931Z
+- **Workflow run:** [25315747534](https://github.com/sattyamjjain/mnemo/actions/runs/25315747534) — `success`
+- Trusted Publisher path (no API token); same configuration as v0.4.2 publish.
+
+## npm
+
+- **Package:** `@mndfreek/mnemo-sdk`
+- **Version:** `0.4.3`
+- **Published-at:** 2026-05-04T06:52:12.006Z
+- **Workflow run:** [25315747537](https://github.com/sattyamjjain/mnemo/actions/runs/25315747537) — `success`
+
+## Post-publish dependabot batch
+
+Four dependabot bumps merged after the v0.4.3 cut, all on 2026-05-04T11:11:48Z–11:11:59Z:
+
+- [#69](https://github.com/sattyamjjain/mnemo/pull/69) — `actions/setup-node` v4 → v6
+- [#70](https://github.com/sattyamjjain/mnemo/pull/70) — `actions/download-artifact` v7 → v8
+- [#71](https://github.com/sattyamjjain/mnemo/pull/71) — `toml` 0.9 → 1.1
+- [#72](https://github.com/sattyamjjain/mnemo/pull/72) — `tokenizers` 0.22 → 0.23
+
+These rebased clean against the v0.4.3 cut once both the `clippy::manual-checked-ops` fix (commit `c6a3063`) and the duckdb idempotent-migrations fix (commit `7894a3a`) were on `main`. Each merge triggered a follow-up `cargo-publish` run that the precheck job correctly identified as a no-op (workspace version unchanged at `0.4.3`).
+
+## Lessons captured for the v0.4.4 cut
+
+- The 300-min `cargo-publish` cap is the **right** ceiling for the current 17-crate workspace. Don't drop it back unless the workspace shrinks.
+- The Trusted Publisher PyPI path (rather than API tokens) continues to work cleanly across releases; no manual operator action required.
+- Each dependabot merge triggers a fresh cargo-publish run that the precheck no-ops on. This is harmless but generates ~5-10 min of CI noise per merge — consider grouping dependabot in `dependabot.yml` to halve the surface (already noted in the 2026-05-03 backlog triage).
+
+## Sources
+
+- cargo-publish workflow run: https://github.com/sattyamjjain/mnemo/actions/runs/25305225245
+- pypi-publish workflow run: https://github.com/sattyamjjain/mnemo/actions/runs/25315747534
+- npm-publish workflow run: https://github.com/sattyamjjain/mnemo/actions/runs/25315747537
+- crates.io API: `https://crates.io/api/v1/crates/<name>/0.4.3`
+- PyPI: https://pypi.org/project/mnemo-db/0.4.3/
+- npm: https://www.npmjs.com/package/@mndfreek/mnemo-sdk/v/0.4.3

--- a/docs/spec-drift-2026-05-04.md
+++ b/docs/spec-drift-2026-05-04.md
@@ -86,3 +86,30 @@ actually lives in the codebase today:
 - v0.4.3 carry list: [CHANGELOG.md](../CHANGELOG.md) `[Unreleased]` section
 - Workers design note: [`docs/src/integrations/cloudflare-workers-deploy.md`](src/integrations/cloudflare-workers-deploy.md)
 - LangGraph adapter (today's Python, tomorrow's Rust): [`python/mnemo/langgraph_mcp.py`](../python/mnemo/langgraph_mcp.py)
+
+## 2026-05-05 stable-divergence confirmation
+
+Today's check (one day after this doc's original creation):
+
+- **Repo description on `main`**: unchanged from the 2026-05-04 record
+  above — still "MCP-native embedded memory database for AI agents
+  built in Rust. REMEMBER/RECALL/FORGET/SHARE primitives with hybrid
+  vector search, AES-256-GCM encryption, DuckDB/PostgreSQL backends &
+  SDKs for Python, TypeScript and Go."
+- **Topics on `main`**: unchanged 14-list (`ai-agents, ai-memory,
+  duckdb, embeddings, encryption, llm-tools, mcp, memory-management,
+  model-context-protocol, postgresql, rag, rust, semantic-search,
+  vector-database`). No `cloudflare`, `langgraph`, or `agent-memory`
+  adds despite v0.4.3 landing the Cloudflare DO Facets anchor and
+  v0.4.4 landing the Project Think anchor — operator policy is still
+  "anchor in docs, not topics, until v0.5.0 marketing decision."
+- **Phase 6 skill template**: still anchors the older description.
+  Not consulted for any v0.4.3 / v0.4.4 surface decision.
+- **Verdict**: **stable divergence the operator has accepted.** Not a
+  regression to flap on. This footer is the durable record of that
+  acceptance — future daily-prompt audits should *not* re-open the
+  question without the operator's explicit prompt.
+
+Next confirmation footer arrives if/when (a) the repo description
+changes on `main`, (b) the topics list gains or loses an entry, or
+(c) a v0.5.0 marketing PR explicitly retires this divergence.

--- a/docs/src/integrations/cloudflare-workers-deploy.md
+++ b/docs/src/integrations/cloudflare-workers-deploy.md
@@ -72,8 +72,26 @@ These are the rows that today sit as `TBD (v0.4.3 bench)` in [`docs/comparisons/
 2. **Tantivy on WASM.** Should compile, but compile time + bundle size matter. Measure before committing.
 3. **DuckDB-on-WASM (`@duckdb/duckdb-wasm`).** An alternative to "Rust core writes to Facet SQLite via a `StorageBackend` impl" — the Worker could host a DuckDB-WASM instance per tenant and persist its file to the Facet's SQLite blob storage. Higher perf parity, but two storage engines and a WASM-on-WASM stack. Trade-off worth measuring.
 
+## Runtime layer (Project Think)
+
+[Cloudflare Project Think](https://blog.cloudflare.com/project-think/)
+(2026-05-04) is the *runtime* story for AI agents on Workers + DO
+Facets — the durable agentic loop itself. Even when the operator
+deploys mnemo onto a Workers + DO Facets substrate following this
+template, **the audit-ledger contract is operator-held and survives
+independent of any Worker's lifecycle.** The HMAC chain, the
+provenance signer's keystore, and `mnemo verify` all run outside
+the Project Think runtime boundary by design.
+
+The full layering rationale (where Project Think wins, where mnemo
+wins, how they compose) is in [`docs/comparisons/cloudflare-project-think.md`](../../comparisons/cloudflare-project-think.md).
+Short version: Project Think owns the loop, mnemo owns the
+audit-ledger, the bench harness above does *not* re-run for Project
+Think because the answer is layering, not benchmarking.
+
 ## Cross-references
 
 - Substrate-level comparison: [`docs/comparisons/cloudflare-agent-memory.md`](../../comparisons/cloudflare-agent-memory.md) — the S1.5 row tracks the DO Facets SQLite vs DuckDB substrate axis.
+- Runtime-layer comparison: [`docs/comparisons/cloudflare-project-think.md`](../../comparisons/cloudflare-project-think.md) — loop vs. ledger, layering not substitution.
 - Comparable embedded-memory pitch in README: see the [`## Why mnemo when Cloudflare Agent Memory exists?`](../../../README.md#why-mnemo-when-cloudflare-agent-memory-exists) section, which already concedes edge-recall p50.
-- v0.4.3 carry list: [`CHANGELOG.md`](../../../CHANGELOG.md) — `mnemo-bench-cf` is on the v0.4.3 backlog with the dependency note attached.
+- v0.4.4 carry list: [`CHANGELOG.md`](../../../CHANGELOG.md) — `mnemo-bench-cf` is on the v0.4.4 backlog with the dependency note attached.


### PR DESCRIPTION
## Summary

Three S-effort docs/test rows for the v0.4.4 cycle. Net-new market trigger: [Cloudflare Project Think](https://blog.cloudflare.com/project-think/) on 2026-05-04 (1 day old at land-time, exactly inside the ≤7d window). All three rows ship docs + tests; **no Rust runtime change, no SDK touch, no breaking change**. Workspace version stays at `0.4.3` — this PR populates the v0.4.4 `[Unreleased]` section without cutting v0.4.4.

### A1 — Cloudflare Project Think positioning anchor

- README `### Project Think — loop vs. ledger` sub-section inside the existing "Why mnemo when Cloudflare Agent Memory exists?" H2. Explicit loop-vs-ledger framing — Project Think is upstream (runtime), mnemo is downstream (audit ledger), **complementary not substitute**.
- New `docs/comparisons/cloudflare-project-think.md` long-form layering doc: where Project Think wins (durable loop, edge-region tick latency, hosted observability), where mnemo wins (offline-verifiable provenance, chain replay, sovereignty round-trip, cross-engine memory ledger), and the canonical stacking pattern (loop on Project Think + DO Facets, audit ledger on operator-held mnemo). Bench harness for *Cloudflare Agent Memory vs mnemo* explicitly does NOT re-run for Project Think — layering question, not benchmark.
- `docs/src/integrations/cloudflare-workers-deploy.md` gains a `## Runtime layer (Project Think)` sub-section linking to the new comparison doc.
- Two new tests: extended marketing-phrase banlist (`competes with Cloudflare`, `replaces Project Think`, `Project Think killer`, `Workers killer`) and `tests/readme_project_think_link.rs` (primary-source URL + heading + comparison-doc-link survival).

### U1 — CHANGELOG `[Unreleased]` v0.4.4 + corrected v0.4.3 verification trace + Sierra evidence + spec-drift footer

- CHANGELOG opens `## [Unreleased]` v0.4.4 section above the existing `## [0.4.3] - 2026-05-04` block.
- **Corrected v0.4.3 verification trace.** The original `### Verification trace (2026-05-04)` sub-block in the v0.4.3 cut PR was authored before the version-flip commit landed — it asserts `Cargo.toml = "0.4.2"` while the live raw fetch shows `"0.4.3"`. New `### Verification trace (2026-05-05)` sub-block records the corrected post-merge state with all artifact-registry checks green; original stays in place as audit history of how the inconsistency arose.
- `docs/comparisons/cloudflare-agent-memory.md` gains an *applied-agent-layer market-evidence* paragraph citing [Sierra's 2026-05-04 $950M raise](https://www.sierra.ai/) at $10B valuation. Tagged explicitly as *market evidence, not a feature claim* — the demand-side substrate is well-funded enough to require a real auditable-memory layer.
- `docs/spec-drift-2026-05-04.md` gains a `## 2026-05-05 stable-divergence confirmation` footer recording today's check: repo description on `main` unchanged, 14 topics unchanged, Phase 6 skill template still anchors the older description. **Stable divergence the operator has accepted, not a regression to flap on.**
- New `tests/changelog_has_unreleased_section.rs` — fails the build if CHANGELOG loses its `## [Unreleased]` heading or if `[Unreleased]` ever appears below a dated release (ordering regression).

### U2 — v0.4.3 publish-status doc

- New `docs/release/v0.4.3-publish-status.md` records the v0.4.3 publish ground truth:
  - **cargo-publish** run [25305225245](https://github.com/sattyamjjain/mnemo/actions/runs/25305225245), `success`, **~253 min** (within the 300-min cap that PR #75 raised the timeout for; the prior 180-min cap would have cancelled this).
  - **17/17 crates** published at `0.4.3` on crates.io with per-crate timestamps from the crates.io API.
  - **PyPI** `mnemo-db@0.4.3` at 2026-05-04T07:11:01Z.
  - **npm** `@mndfreek/mnemo-sdk@0.4.3` at 2026-05-04T06:52:12Z.
  - 4 post-cut dependabot bumps (#69, #70, #71, #72) merged 11:11:48–11:11:59Z; each triggered a no-op cargo-publish run (workspace version unchanged).
- New `tests/release_status_doc_present.rs` — fails the build if the publish-status doc disappears or stops listing all 17 crates.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --workspace --exclude mnemo-python -- -D warnings` clean (CI invocation)
- [x] `cargo test --workspace --exclude mnemo-python --no-fail-fast` — **347 passed**, 0 failed, 5 ignored (was 341 on v0.4.3; +6 from the three new test files)
- [x] All 6 new test functions pass: 2 `readme_project_think_link` + 2 `changelog_has_unreleased_section` + 2 `release_status_doc_present`
- [x] Existing 6 readme + skew-matrix tests still green (`readme_no_marketing_phrases` extended banlist + `readme_workers_template_link` + `readme_carries_required_cloudflare_section_anchor` + `sdk_matrix_doc_present` + Cloudflare-substrate annotation test)

## Sources

- https://blog.cloudflare.com/project-think/ (Cloudflare Project Think announcement, 2026-05-04 — A1 primary URL)
- https://blog.cloudflare.com/durable-object-facets-dynamic-workers/ (DO Facets, 2026-04-30 — yesterday's anchor, still cited)
- https://www.sierra.ai/ (Sierra $950M raise, 2026-05-04 — U1 applied-layer evidence)
- https://github.com/sattyamjjain/mnemo/actions/runs/25305225245 (v0.4.3 cargo-publish run — U2 ground truth)
- https://crates.io/api/v1/crates/mnemo-core/0.4.3 (per-crate published-at timestamp source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)