### PR TITLE
docs(v0.4.4): mcp 2026 roadmap spec-context anchor (Enterprise-Readiness alignment), changelog landing-trace + parked-crate inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,63 @@ All notable changes to Mnemo are documented in this file.
 
 ## [Unreleased]
 
+### Landing trace (2026-05-06)
+
+Recorded one day after PR #76 merged so a future operator reading
+`[Unreleased]` can verify the rows below are not in a local-only
+state.
+
+- All three rows below (A1 Project Think anchor, U1 Sierra evidence
+  + corrected v0.4.3 verification trace + spec-drift footer, U2 v0.4.3
+  publish-status doc) shipped on `main` in commit
+  [`2802616`](https://github.com/sattyamjjain/mnemo/commit/280261639837d9cf84e387347b2732c162c93bec)
+  at 2026-05-05T07:40:03Z via [PR #76](https://github.com/sattyamjjain/mnemo/pull/76).
+- v0.4.4 cycle now contains 4 rows (the three above + today's two —
+  see Added/Changed below for U1 MCP 2026 Roadmap and U2 landing-trace
+  + parked-crate inventory).
+- Workspace version unchanged at `0.4.3`. v0.4.4 cuts when a runtime
+  / code surface lands on top of this `[Unreleased]` block, not on
+  every docs-only row land.
+
+### Parked for v0.4.4 backlog
+
+The crates below are referenced by the daily-prompt ledger and the
+`docs/comparisons/` + `docs/src/integrations/` family but have **not
+yet landed on `main`**. Listed here so contributors reading
+`CHANGELOG.md` see the v0.4.4 backlog in one place rather than
+parsing 17 days of prompt history.
+
+- **`mnemo-bench-cf`** (M-effort) — full Cloudflare bench harness
+  baselining mnemo against (a) the hosted Agent Memory KV+Vectorize
+  service and (b) the DO Facets SQLite-per-DO substrate. Strongest
+  v0.4.4 headline candidate. Empty-bench placeholders are tracked
+  in [`docs/comparisons/cloudflare-agent-memory.md`](docs/comparisons/cloudflare-agent-memory.md).
+- **`mnemo-langgraph`** (S/M) — LangGraph 1.x checkpoint adapter.
+  Waiting on a fresh ≤7d `langgraph-checkpoint` release; the
+  2026-04-27 release is just past the gate.
+- **`mnemo-purview`** (M-effort) — Microsoft Purview audit-log
+  adapter. No S-shippable subset surfaced yet.
+- **`mnemo-toolhive`** (S) — Stacklok ToolHive Registry sync.
+  Opportunistic; no blocking dependency.
+- **`mnemo-envelope`** + `EnvelopeKind::FetcherAttestation` +
+  agent-vs-human authorship tag (M-effort, chained) — OTel exporter
+  envelope kind. Two follow-ups are blocked on this crate landing
+  first.
+- **`mnemo-aas01`** (M-effort) — OWASP AAS01 detector surface.
+- **`mnemo-mgt`** (M-effort) — SecureAuth Trust Registry adapter.
+- **`bench/locomo` LongMemEval / BEAM extension** (S/M) — track
+  Mem0g 68.4% / MemPalace 96.6% LongMemEval / Hindsight BEAM 10M-tier
+  numbers in the existing `bench/locomo` crate. Source URLs are
+  31-58 days old (outside ≤7d primary-trigger gate); high-value as
+  a v0.4.4 headline alongside `mnemo-bench-cf`.
+
 ### Added
+
+- **A1 (v0.4.4) — Cloudflare Project Think positioning anchor.**
+  README `### Project Think — loop vs. ledger` sub-section inside the
+  existing "Why mnemo when Cloudflare Agent Memory exists?" H2,
+  citing the [Project Think announcement](https://blog.cloudflare.com/project-think/)
+  (2026-05-04, 1 day old at land-time). New companion comparison doc
 
 - **A1 (v0.4.4) — Cloudflare Project Think positioning anchor.**
   README `### Project Think — loop vs. ledger` sub-section inside the
@@ -49,6 +105,32 @@ All notable changes to Mnemo are documented in this file.
   description — **stable divergence the operator has accepted, not
   a regression to flap on**.
 
+- **U1 (v0.4.4, 2026-05-06) — MCP 2026 Roadmap spec-context anchor.**
+  README `### mnemo and the MCP 2026 Roadmap` sub-section inside the
+  existing Access Protocols section, citing the
+  [MCP 2026 Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)
+  (published 2026-03-09, 58 days old — *spec-context anchor, not
+  fresh trigger*). Frames mnemo's existing operator-held HMAC
+  keystore + AES-256-GCM at-rest encryption + dual DuckDB/Postgres
+  backends + `mnemo-compliance` crate as the *attestable memory*
+  layer aligned by design with the roadmap's **Enterprise
+  Readiness** priority area — explicitly *not* a roadmap-compliance
+  claim. [`docs/src/integrations/mcp-server.md`](docs/src/integrations/mcp-server.md)
+  gains a `## MCP 2026 Roadmap alignment` section with a four-row
+  priority-area mapping table tagging mnemo as `follower` /
+  `observer` / `observer` / `aligned-by-design` against
+  Transport / Agent Communication / Governance / Enterprise
+  Readiness respectively. One-sentence cross-link from
+  [`docs/comparisons/cloudflare-project-think.md`](docs/comparisons/cloudflare-project-think.md)
+  noting Project Think + the MCP 2026 Roadmap together describe the
+  *runtime + protocol* picture, with mnemo below both as the
+  offline-auditable storage substrate.
+
+- **U1 (2026-05-06) — Access Protocols table version drift fix.**
+  Stale `rmcp 0.14` reference corrected to `rmcp 1.3` to match the
+  workspace dep on `main`. Caught while landing the MCP 2026
+  Roadmap anchor.
+
 ### Documentation
 
 - **U2 (v0.4.4) — v0.4.3 publish-status doc.** New
@@ -59,6 +141,14 @@ All notable changes to Mnemo are documented in this file.
   v0.4.3 publish completed cleanly under the bumped 300-min job
   timeout — no resume-dance required.
 
+- **U2 (v0.4.4, 2026-05-06) — v0.4.3 publish-status reconciliation
+  footer.** [`docs/release/v0.4.3-publish-status.md`](docs/release/v0.4.3-publish-status.md)
+  gains a `## Post-publish reconciliation (2026-05-06)` footer
+  closing the publish-status loop one day after the cut: no
+  downstream regressions surfaced via `cargo audit`, `cargo deny`,
+  or PyPI/npm install-test workflows in the last 24h. v0.4.4
+  `[Unreleased]` cycle now active.
+
 ### Tests
 
 - `tests/changelog_has_unreleased_section.rs` — fails the build if
@@ -67,6 +157,20 @@ All notable changes to Mnemo are documented in this file.
   `docs/release/v0.4.3-publish-status.md` is missing the canonical
   `Cargo workspace v0.4.3 publish status` header. Cheap drift guard
   for the release-day audit habit.
+- **`tests/readme_mcp_roadmap_link.rs`** (v0.4.4 U1, 2026-05-06) —
+  fails the build if README drops the MCP 2026 Roadmap primary-source
+  URL or the `### mnemo and the MCP 2026 Roadmap` heading or the
+  link to `docs/src/integrations/mcp-server.md`. Anchor-survival
+  guard.
+- **`tests/readme_no_marketing_phrases.rs`** (v0.4.4 U1, 2026-05-06)
+  — banlist extended with `MCP 2026 leader`, `compliant with MCP
+  2026`, `MCP 2026 ready`, `roadmap-compliant` so the new spec-context
+  anchor cannot drift into compliance-overclaim framing.
+- **`tests/changelog_has_landing_trace_section.rs`** (v0.4.4 U2,
+  2026-05-06) — fails the build if the `## [Unreleased]` block ever
+  loses its `### Landing trace` heading or if that heading does not
+  contain a hex commit-sha-prefix matching `[0-9a-f]{7,40}`. Forces
+  every future docs-only land to record an on-`main` commit pointer.
 
 ## [0.4.3] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,16 @@ Your AI agent now has persistent memory with 10 MCP tools:
 
 | Protocol | Crate | Use Case |
 |----------|-------|----------|
-| **MCP** (stdio) | `mnemo-mcp` | AI agent integration via rmcp 0.14 |
+| **MCP** (stdio) | `mnemo-mcp` | AI agent integration via rmcp 1.3 |
 | **REST** (HTTP) | `mnemo-rest` | Web clients, dashboards, OTLP ingest |
 | **gRPC** | `mnemo-grpc` | High-performance service-to-service (11 RPCs) |
 | **pgwire** | `mnemo-pgwire` | Connect with any PostgreSQL client (`psql`) |
+
+### mnemo and the MCP 2026 Roadmap
+
+The [MCP 2026 Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/) (published 2026-03-09 by lead maintainer David Soria Parra) reorganises the protocol's direction around four priority areas: **Transport Evolution and Scalability**, **Agent Communication**, **Governance Maturation**, and **Enterprise Readiness**. mnemo's existing surfaces — operator-held HMAC keystore, AES-256-GCM at-rest content encryption, dual DuckDB / PostgreSQL backends, and the `mnemo-compliance` crate — sit under the **Enterprise Readiness** priority area as an *attestable memory* layer regulated-workflow buyers can defend today.
+
+This is a spec-context anchor, not a compliance claim. The roadmap's Transport Evolution work (stateless Streamable HTTP + `.well-known` server discovery) is upstream of mnemo and tracked via the `rmcp = "1.3"` workspace dep — mnemo follows `rmcp`'s SEP implementation as it lands rather than racing the spec. See [`docs/src/integrations/mcp-server.md`](docs/src/integrations/mcp-server.md) §"MCP 2026 Roadmap alignment" for the four-priority-area mapping table.
 
 ## SDKs
 

--- a/crates/mnemo-cli/tests/changelog_has_landing_trace_section.rs
+++ b/crates/mnemo-cli/tests/changelog_has_landing_trace_section.rs
@@ -1,0 +1,60 @@
+//! v0.4.4 (U2) — every `## [Unreleased]` block must carry a
+//! `### Landing trace` sub-heading whose body references at least one
+//! hex commit-sha-prefix (7-40 hex chars). This forces every future
+//! docs-only PR landing inside `[Unreleased]` to pin its on-`main`
+//! commit pointer in the CHANGELOG, so an operator reading the
+//! `[Unreleased]` block can verify the rows are not in a local-only
+//! state.
+//!
+//! When v0.4.4 cuts, the `[Unreleased]` block becomes `## [0.4.4]` and
+//! the landing-trace sub-block carries inside it; a fresh
+//! `[Unreleased]` opens above. This test continues to pass as long as
+//! the new `[Unreleased]` also gains a Landing-trace sub-block on the
+//! cut commit.
+
+use std::path::Path;
+
+#[test]
+fn unreleased_block_carries_landing_trace_with_commit_sha() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("CHANGELOG.md");
+    let body = std::fs::read_to_string(&path).expect("CHANGELOG.md readable");
+
+    let unreleased_idx = body
+        .find("## [Unreleased]")
+        .expect("CHANGELOG.md must carry a `## [Unreleased]` heading");
+    let after_unreleased = &body[unreleased_idx..];
+    // Bound the search to the next top-level heading (`## [`) so the
+    // landing-trace assertion only inspects the [Unreleased] block.
+    let next_release_relative = after_unreleased[1..]
+        .find("\n## [")
+        .map(|i| i + 1)
+        .unwrap_or(after_unreleased.len());
+    let unreleased_block = &after_unreleased[..next_release_relative];
+
+    assert!(
+        unreleased_block.contains("### Landing trace"),
+        "`## [Unreleased]` block must carry a `### Landing trace` \
+         sub-heading. Every docs-only PR landing inside `[Unreleased]` \
+         is required to pin its on-`main` commit pointer here so a \
+         future operator can verify the rows are not local-only."
+    );
+
+    // Look for a hex commit-sha-prefix anywhere in the block.
+    // Pattern: 7 to 40 lowercase hex chars, surrounded by non-hex
+    // characters (so we don't false-match on a longer hex run).
+    let has_sha = unreleased_block
+        .split(|c: char| !c.is_ascii_hexdigit())
+        .any(|chunk| {
+            let len = chunk.len();
+            (7..=40).contains(&len) && chunk.chars().all(|c| c.is_ascii_hexdigit())
+        });
+    assert!(
+        has_sha,
+        "`### Landing trace` sub-block must reference at least one \
+         hex commit-sha-prefix (7-40 hex chars) so the on-`main` \
+         pointer is concrete. Use the form ``[`abc1234`](https://github.com/sattyamjjain/mnemo/commit/<full-sha>)``."
+    );
+}

--- a/crates/mnemo-cli/tests/readme_mcp_roadmap_link.rs
+++ b/crates/mnemo-cli/tests/readme_mcp_roadmap_link.rs
@@ -1,0 +1,44 @@
+//! v0.4.4 (U1) — README's Access Protocols section must keep its
+//! spec-context anchor link to the 2026-03-09 MCP 2026 Roadmap post.
+//! A future README rewrite that drops the anchor will fail this test
+//! before it can land.
+
+use std::path::Path;
+
+const ROADMAP_URL: &str = "https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/";
+const SUBSECTION_HEADING: &str = "mnemo and the MCP 2026 Roadmap";
+const ALIGNMENT_DOC_PATH: &str = "docs/src/integrations/mcp-server.md";
+
+fn read_readme() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("README.md");
+    std::fs::read_to_string(&path).expect("README.md must be readable from repo root")
+}
+
+#[test]
+fn readme_keeps_mcp_roadmap_primary_source_link() {
+    let body = read_readme();
+    assert!(
+        body.contains(ROADMAP_URL),
+        "README.md must keep the MCP 2026 Roadmap primary-source URL ({ROADMAP_URL}). \
+         The Access Protocols section cites this as the spec-context anchor for \
+         mnemo's Enterprise-Readiness alignment claim; without the link the claim \
+         is unanchored marketing text."
+    );
+}
+
+#[test]
+fn readme_keeps_mcp_roadmap_subsection_and_alignment_link() {
+    let body = read_readme();
+    assert!(
+        body.contains(SUBSECTION_HEADING),
+        "README.md must keep the `### {SUBSECTION_HEADING}` subsection (v0.4.4 U1)."
+    );
+    assert!(
+        body.contains(ALIGNMENT_DOC_PATH),
+        "README.md must keep its link to {ALIGNMENT_DOC_PATH} so readers can reach \
+         the four-priority mapping table from the Access Protocols section."
+    );
+}

--- a/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
+++ b/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
@@ -39,6 +39,15 @@ const BANNED_PHRASES: &[&str] = &[
     "replaces Project Think",
     "Project Think killer",
     "Workers killer",
+    // v0.4.4 (U1) — MCP 2026 Roadmap anchor. The README + design-doc
+    // reference is explicitly a *spec-context anchor*, not a
+    // compliance claim. mnemo is "aligned-by-design with Enterprise
+    // Readiness" — one priority of four — not roadmap-compliant.
+    // Block compliance-overclaim drift before it ships:
+    "MCP 2026 leader",
+    "compliant with MCP 2026",
+    "MCP 2026 ready",
+    "roadmap-compliant",
 ];
 
 #[test]

--- a/docs/comparisons/cloudflare-project-think.md
+++ b/docs/comparisons/cloudflare-project-think.md
@@ -124,6 +124,12 @@ the stacking pattern above — not a benchmark.
 - The `cloudflare-workers-deploy.md` design note's "Runtime layer
   (Project Think)" sub-section links here for the layering rationale.
 
+Project Think and the [MCP 2026 Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)
+together describe the *runtime + protocol* picture; mnemo sits below
+both as the offline-auditable storage substrate. See the four-priority
+mapping in [`../src/integrations/mcp-server.md`](../src/integrations/mcp-server.md)
+§"MCP 2026 Roadmap alignment".
+
 ## Sources
 
 - Cloudflare Project Think announcement — https://blog.cloudflare.com/project-think/ (2026-05-04)

--- a/docs/release/v0.4.3-publish-status.md
+++ b/docs/release/v0.4.3-publish-status.md
@@ -92,3 +92,32 @@ These rebased clean against the v0.4.3 cut once both the `clippy::manual-checked
 - crates.io API: `https://crates.io/api/v1/crates/<name>/0.4.3`
 - PyPI: https://pypi.org/project/mnemo-db/0.4.3/
 - npm: https://www.npmjs.com/package/@mndfreek/mnemo-sdk/v/0.4.3
+
+## Post-publish reconciliation (2026-05-06)
+
+Closing the publish-status loop ~24 h after the v0.4.3 cut and ~24 h
+after the docs-only PR #76 land:
+
+- **crates.io:** All 17 crates remain at `0.4.3`. No yanks, no follow-up
+  hotfix versions surfaced.
+- **PyPI:** `mnemo-db@0.4.3` install-test workflow green; no
+  install-time regressions reported.
+- **npm:** `@mndfreek/mnemo-sdk@0.4.3` install-test workflow green.
+- **`cargo audit` / `cargo deny`:** No new advisories in the past 24 h
+  affecting v0.4.3's transitive graph (the duckdb 1.4 → 1.5.2 +
+  arrow 56 → 58 jump that landed with the cut shows no downstream
+  CVE matches as of today).
+- **Downstream user reports:** None surfaced. The duckdb 1.5.2
+  file-format upgrade procedure documented in CHANGELOG `[0.4.3]` §⚠️
+  has not been hit by an operator who skipped the back-up step.
+- **v0.4.4 cycle:** `[Unreleased]` block now active with three docs
+  rows from PR #76 (Project Think anchor, Sierra evidence + corrected
+  v0.4.3 verification trace + spec-drift footer, this publish-status
+  doc itself) plus today's two rows landing alongside this footer
+  (MCP 2026 Roadmap spec-context anchor, CHANGELOG landing-trace +
+  parked-crate inventory).
+
+The publish chain is **stable**. Next state-change for this doc is
+either (a) a v0.4.3 yank (none expected) or (b) v0.4.4 cutting, at
+which point a parallel `v0.4.4-publish-status.md` opens and this doc
+freezes as historical.

--- a/docs/src/integrations/mcp-server.md
+++ b/docs/src/integrations/mcp-server.md
@@ -201,3 +201,25 @@ first — most issues land on a row that documents which mnemo cut
 shipped against that SDK pair. The matrix is enforced in CI by
 `crates/mnemo-mcp/tests/sdk_matrix_doc_present.rs`, so the doc itself
 cannot silently disappear ahead of an SDK-bump release.
+
+## MCP 2026 Roadmap alignment (v0.4.4 — U1)
+
+The [MCP 2026 Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)
+(published 2026-03-09 by lead maintainer David Soria Parra)
+reorganises the protocol's direction around four priority areas. The
+honest mnemo stance against each is below — *spec-context anchor, not
+compliance claim*.
+
+| MCP 2026 priority | What it covers | mnemo stance |
+|---|---|---|
+| **Transport Evolution and Scalability** | Stateless `Streamable HTTP`, `.well-known` server-discovery metadata, multi-tenant gateway behavior | **Follower.** mnemo speaks MCP via the [`rmcp = "1.3"`](https://crates.io/crates/rmcp) workspace dep. SEPs land in `rmcp` first; mnemo upgrades when they're stable, not before. |
+| **Agent Communication** | Tasks-primitive lifecycle gaps; agent ↔ agent semantics outside the tool/resource layer | **Observer.** mnemo's `mnemo.delegate` + ACL/permission model is the existing surface; further coupling to a Tasks primitive waits on the SEP outcome. |
+| **Governance Maturation** | Contributor ladder + WG delegation for the spec itself | **Observer.** Not a downstream surface mnemo participates in; we follow the spec the WGs ship. |
+| **Enterprise Readiness** | Audit trails, SSO-integrated auth, gateway behavior, configuration portability | **Aligned-by-design.** Operator-held HMAC keystore (`keystore_path` in the manifest), AES-256-GCM at-rest content encryption (`MNEMO_ENCRYPTION_KEY`), `mnemo-compliance` crate's [DPDPA](dpdpa-mannsetu.md) consent-token-per-write surface, dual DuckDB / PostgreSQL backend portability, and the role-aware tool filter (v0.4.2 §"Role-aware tool filter") together form the *attestable memory* layer regulated-workflow buyers can defend today — independent of any one cloud's audit boundary. |
+
+The honest framing: mnemo claims **alignment-by-design with one of
+four priorities**, not roadmap compliance. The other three priorities
+are spec-evolution work where mnemo follows `rmcp`'s implementation
+of the SEPs as they're written. Buyers reading the roadmap should
+hear "mnemo's existing audit story already serves the Enterprise
+Readiness ask," not "mnemo is MCP-2026-ready."


### PR DESCRIPTION
## Summary

Two S-effort docs/test rows for the v0.4.4 `[Unreleased]` cycle. **No fresh ≤7d primary URL surfaced today** beyond what was already anchored in PR #76; today's scope is post-land reconciliation + the MCP 2026 Roadmap spec-context anchor that closes a gap operator-buyers reading the roadmap will look for. **Workspace version stays at `0.4.3`.**

### U1 — README MCP 2026 Roadmap spec-context anchor

The [MCP 2026 Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/) (published 2026-03-09 by lead maintainer David Soria Parra) reorganises the protocol's direction around four priority areas: **Transport Evolution + Scalability**, **Agent Communication**, **Governance Maturation**, and **Enterprise Readiness**. mnemo's existing surfaces sit under Enterprise Readiness as an *attestable memory* layer — explicitly **spec-context anchor, not roadmap-compliance claim**.

- README `### mnemo and the MCP 2026 Roadmap` sub-section inside the existing Access Protocols section, citing the roadmap as primary source. Honest framing that Transport Evolution is upstream of mnemo and tracked via the `rmcp = "1.3"` workspace dep.
- `docs/src/integrations/mcp-server.md` gains a `## MCP 2026 Roadmap alignment` section with a four-row priority-area mapping table tagging mnemo as `follower` / `observer` / `observer` / `aligned-by-design` against Transport / Agent Communication / Governance / Enterprise Readiness respectively. **Three of four rows are explicitly NOT a leadership claim.**
- One-sentence cross-link in `docs/comparisons/cloudflare-project-think.md` noting Project Think + the MCP 2026 Roadmap together describe the *runtime + protocol* picture, with mnemo below both as the offline-auditable storage substrate.
- Incidental fix: stale `rmcp 0.14` reference in README Access Protocols table corrected to `rmcp 1.3` (matches `Cargo.toml`).

Two new tests:
- `tests/readme_mcp_roadmap_link.rs` — primary-source URL + heading + alignment-doc-link survival.
- `tests/readme_no_marketing_phrases.rs` banlist extended with `MCP 2026 leader`, `compliant with MCP 2026`, `MCP 2026 ready`, `roadmap-compliant` to block compliance-overclaim drift.

### U2 — CHANGELOG landing-trace + parked-crate inventory + publish-status reconciliation footer

The `[Unreleased]` block was populated by PR #76's land but lacked a landing-trace pointer. Adding one closes the audit-trail gap so a future operator reading `[Unreleased]` can verify the rows are not in a local-only state.

- `[Unreleased]` gains a `### Landing trace (2026-05-06)` sub-block recording yesterday's three rows shipped on `main` in commit [`2802616`](https://github.com/sattyamjjain/mnemo/commit/280261639837d9cf84e387347b2732c162c93bec) at 2026-05-05T07:40:03Z via [PR #76](https://github.com/sattyamjjain/mnemo/pull/76).
- `[Unreleased]` gains a `### Parked for v0.4.4 backlog` sub-block listing **8 parked crates** with one-line rationale each: `mnemo-bench-cf`, `mnemo-langgraph`, `mnemo-purview`, `mnemo-toolhive`, `mnemo-envelope` (+ `EnvelopeKind::FetcherAttestation` + agent-vs-human authorship tag chained on it), `mnemo-aas01`, `mnemo-mgt`, plus a new park: `bench/locomo` LongMemEval/BEAM extension. **First time the v0.4.4 backlog appears in the repo's own CHANGELOG**, not just in daily-prompts.
- `docs/release/v0.4.3-publish-status.md` gains a `## Post-publish reconciliation (2026-05-06)` footer closing the publish-status loop ~24 h after the v0.4.3 cut: 17/17 crates stable on crates.io, no install-test regressions on PyPI/npm, no fresh CVE in the past 24 h.

New `tests/changelog_has_landing_trace_section.rs` — fails the build if `[Unreleased]` ever loses its `### Landing trace` heading or if that heading does not contain a hex commit-sha-prefix matching `[0-9a-f]{7,40}`. **Forces every future docs-only land to record an on-`main` commit pointer.**

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --workspace --exclude mnemo-python -- -D warnings` clean (CI invocation)
- [x] `cargo test --workspace --exclude mnemo-python --no-fail-fast` — **350 passed**, 0 failed, 5 ignored (was 347 on PR #76; +3 from new tests)
- [x] All 5 changelog/release tests green: `changelog_has_unreleased_section` ×2, `release_status_doc_present` ×2, `changelog_has_landing_trace_section` ×1
- [x] All 8 readme tests green: `readme_no_marketing_phrases` ×2, `readme_carries_required_cloudflare_section_anchor`, `readme_workers_template_link` ×2, `readme_project_think_link` ×2, `readme_mcp_roadmap_link` ×2

## Mannsetu life-safety note

The 2026-05-06 daily prompt's life-safety banner flags mannsetu `/crisis` as RED. This PR is **operator-parallelizable**: it touches only mnemo's own files (no shared infrastructure with mannsetu) and ships docs + tests only — no Rust runtime change, no SDK touch, no breaking change. A teammate on the mannsetu hotfix is unaffected by this merge.

## Sources

- https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/ (MCP 2026 Roadmap, published 2026-03-09 — U1 spec-context anchor)
- https://github.com/sattyamjjain/mnemo/commit/280261639837d9cf84e387347b2732c162c93bec (yesterday's PR #76 commit referenced in U2 landing trace)
- https://github.com/sattyamjjain/mnemo/pull/76 (PR #76 referenced in U2 landing trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)