### PR TITLE
docs(v0.4.4): dreams research-preview substrate anchor + argus 2605.03378 provenance composition anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,27 @@ parsing 17 days of prompt history.
 
 ### Added
 
+- **U1 (v0.4.4, 2026-05-09) — Anthropic Dreams Research Preview substrate
+  anchor.** README `### Memory curation interop (Dreams, Routines, and
+  substrate primitives)` sub-section inside Key Features, citing the
+  [Dreams Research Preview docs](https://platform.claude.com/docs/en/managed-agents/dreams)
+  (surfaced 2026-05-06 at Code w/ Claude SF, 3 days old at land-time)
+  and the companion [Routines doc](https://code.claude.com/docs/en/routines).
+  New companion comparison doc
+  [`docs/comparisons/anthropic-dreams.md`](docs/comparisons/anthropic-dreams.md)
+  with curator-action ↔ substrate-primitive layering table; explicit
+  non-overlap callout (Dreams owns *what to curate*, mnemo owns *how
+  to durably store with audit trail*). One-sentence cross-link from
+  [`docs/comparisons/cloudflare-project-think.md`](docs/comparisons/cloudflare-project-think.md)
+  noting Project Think (runtime) + MCP 2026 Roadmap (protocol) +
+  Dreams (curator) together describe the runtime + protocol + curator
+  picture, with mnemo as the offline-auditable substrate underneath.
+  **Honest framing:** the Dreams API is Research Preview behind a
+  Request-access form; **mnemo does NOT today ship an Anthropic-API
+  adapter.** A `mnemo-dreams` adapter crate is plausible if/when the
+  API exits Research Preview but is explicitly NOT on the v0.4.x
+  backlog.
+
 - **A1 (v0.4.4) — Cloudflare Project Think positioning anchor.**
   README `### Project Think — loop vs. ledger` sub-section inside the
   existing "Why mnemo when Cloudflare Agent Memory exists?" H2,
@@ -149,6 +170,23 @@ parsing 17 days of prompt history.
   or PyPI/npm install-test workflows in the last 24h. v0.4.4
   `[Unreleased]` cycle now active.
 
+- **U2 (v0.4.4, 2026-05-09) — ARGUS provenance composition anchor.**
+  [`docs/comparisons/cloudflare-agent-memory.md`](docs/comparisons/cloudflare-agent-memory.md)
+  gains a `## Read-side composition: ARGUS provenance auditing
+  (2026-05-09)` section pairing mnemo's *write-side* HMAC envelope
+  chain with [arXiv 2605.03378](https://arxiv.org/abs/2605.03378)'s
+  *read-side* decision-auditing model for context-aware prompt
+  injection (submitted 2026-05-05, 4 days old at land-time). New
+  companion research-anchor doc
+  [`docs/research/argus-2605.03378.md`](docs/research/argus-2605.03378.md)
+  walking through what ARGUS does, where mnemo fits, and what this
+  note is explicitly NOT (not an implementation, not a compliance
+  claim, not a benchmark). Composition-anchor framing throughout —
+  compositional-security overclaim phrasings (`prompt-injection-proof`,
+  `provenance-guaranteed`, `ARGUS-compliant`,
+  `injection-resistant by construction`) banned by the extended
+  marketing-phrase test below.
+
 ### Tests
 
 - `tests/changelog_has_unreleased_section.rs` — fails the build if
@@ -171,6 +209,21 @@ parsing 17 days of prompt history.
   loses its `### Landing trace` heading or if that heading does not
   contain a hex commit-sha-prefix matching `[0-9a-f]{7,40}`. Forces
   every future docs-only land to record an on-`main` commit pointer.
+- **`tests/readme_dreams_link.rs`** (v0.4.4 U1, 2026-05-09) — fails
+  the build if README drops the Anthropic Dreams Research Preview
+  primary-source URL, the `### Memory curation interop` heading, the
+  link to `docs/comparisons/anthropic-dreams.md`, or the literal
+  `Research Preview` honesty disclaimer.
+- **`tests/research_doc_argus_present.rs`** (v0.4.4 U2, 2026-05-09)
+  — fails the build if `docs/research/argus-2605.03378.md` is
+  missing the arXiv URL or the `Composition anchor, not a compliance
+  claim` standing-rule disclaimer.
+- **`tests/readme_no_marketing_phrases.rs`** (v0.4.4 U1+U2,
+  2026-05-09) — banlist extended with five Dreams overclaim phrasings
+  (`Dreams replacement`, `dream-compatible`, `Dreams-ready`,
+  `Dreams competitor`, `curator killer`) and four compositional-security
+  overclaim phrasings (`prompt-injection-proof`, `provenance-guaranteed`,
+  `ARGUS-compliant`, `injection-resistant by construction`).
 
 ## [0.4.3] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ _, _ = client.Share(mnemo.ShareInput{MemoryID: result.ID, TargetAgentID: "audito
 - **mnemo doctor + Grafana dashboard** — typed `DoctorReport` + `DoctorFix` recommendations and a committed `dashboards/mnemo-grafana.json` (schemaVersion 39) covering recall p50/p99, tool-catalog drift, HMAC continuity, code-mode token reduction. New in v0.4.1.
 - **MCP role-aware tool filter** — manifest `[role_filter]` block with `caller_roles`, `default = "allow_all" | "deny_all"`, per-tool `allow` / `deny` maps (deny wins), and an `McpRoleDenied` audit row on every blocked call. Aligned with the [2025-11-25 MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization). Omitting the block keeps pre-v0.4.2 behaviour byte-for-byte. New in v0.4.2.
 
+### Memory curation interop (Dreams, Routines, and substrate primitives)
+
+Anthropic's [Dreams Research Preview](https://platform.claude.com/docs/en/managed-agents/dreams) (surfaced 2026-05-06 at Code w/ Claude SF) is a managed-agent feature that "lets Claude reflect on past sessions to curate an agent's memory and surface new insights." Its companion [Routines doc](https://code.claude.com/docs/en/routines) describes the long-horizon agents that *consume* curated memory. mnemo's REMEMBER / RECALL / FORGET / SHARE primitives, envelope provenance, and AES-256-GCM at-rest encryption are the substrate any such curator reads from and writes through — Dreams owns *what to curate*, mnemo owns *how to durably store with audit trail*. The two surfaces are complementary, not substitute.
+
+**Honest framing:** the Dreams API itself is a Research Preview behind a Request-access form, and **mnemo does NOT today ship an Anthropic-API adapter**. Today's anchor is substrate-level interop documentation, not integration. A `mnemo-dreams` adapter crate is plausible if/when the API exits Research Preview, but is explicitly NOT in scope for v0.4.x. See [`docs/comparisons/anthropic-dreams.md`](docs/comparisons/anthropic-dreams.md) for the curator-action ↔ mnemo-primitive layering table.
+
 ## Why mnemo when Cloudflare Agent Memory exists?
 
 Cloudflare announced Agent Memory GA during [Agents Week (2026-04-30)](https://www.cloudflare.com/agents-week/updates/),

--- a/crates/mnemo-cli/tests/readme_dreams_link.rs
+++ b/crates/mnemo-cli/tests/readme_dreams_link.rs
@@ -1,0 +1,79 @@
+//! v0.4.4 (2026-05-09 U1) — README's Memory curation interop subsection
+//! must keep its primary-source anchor to the 2026-05-06 Anthropic
+//! Dreams Research Preview docs page and its companion comparison
+//! doc. A future README rewrite that drops either anchor will fail
+//! this test before it can land.
+
+use std::path::Path;
+
+const DREAMS_URL: &str = "https://platform.claude.com/docs/en/managed-agents/dreams";
+const SUBSECTION_HEADING: &str = "Memory curation interop";
+const COMPARISON_DOC_PATH: &str = "docs/comparisons/anthropic-dreams.md";
+const RESEARCH_PREVIEW_DISCLAIMER: &str = "Research Preview";
+
+fn read_readme() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("README.md");
+    std::fs::read_to_string(&path).expect("README.md must be readable from repo root")
+}
+
+#[test]
+fn dreams_subsection_keeps_primary_source_link() {
+    let body = read_readme();
+    assert!(
+        body.contains(DREAMS_URL),
+        "README.md must keep the Anthropic Dreams Research Preview \
+         primary-source URL ({DREAMS_URL}). The Memory curation interop \
+         subsection without the anchor would be marketing text, not a \
+         technical pointer."
+    );
+}
+
+#[test]
+fn dreams_subsection_keeps_heading_word_dreams() {
+    let body = read_readme();
+    assert!(
+        body.contains(SUBSECTION_HEADING),
+        "README.md must keep the `### {SUBSECTION_HEADING}` subsection \
+         (v0.4.4 2026-05-09 U1)."
+    );
+    // The heading line must contain the literal word "Dreams" so
+    // future grep-based discovery (and TOC tooling) keeps working.
+    let heading_line = body
+        .lines()
+        .find(|line| line.contains(SUBSECTION_HEADING))
+        .expect("subsection heading line must be findable");
+    assert!(
+        heading_line.contains("Dreams"),
+        "the `### {SUBSECTION_HEADING}` heading line must mention `Dreams` \
+         literally — found instead: {heading_line:?}"
+    );
+}
+
+#[test]
+fn dreams_subsection_links_to_comparison_doc() {
+    let body = read_readme();
+    assert!(
+        body.contains(COMPARISON_DOC_PATH),
+        "README.md must keep its link to {COMPARISON_DOC_PATH} so \
+         readers can reach the curator-action ↔ substrate-primitive \
+         layering table from the Memory curation interop subsection."
+    );
+}
+
+#[test]
+fn dreams_paragraph_carries_research_preview_honesty_disclaimer() {
+    // The Dreams API is Research Preview behind a Request-access
+    // form. The README paragraph must say so explicitly — this is
+    // the operator's standing rule against integration-overclaim.
+    let body = read_readme();
+    assert!(
+        body.contains(RESEARCH_PREVIEW_DISCLAIMER),
+        "README.md Memory curation interop subsection must carry the \
+         literal phrase `{RESEARCH_PREVIEW_DISCLAIMER}` so readers know \
+         the Dreams API is not GA. Removing this disclaimer would slide \
+         the section into integration-overclaim territory."
+    );
+}

--- a/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
+++ b/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
@@ -48,6 +48,26 @@ const BANNED_PHRASES: &[&str] = &[
     "compliant with MCP 2026",
     "MCP 2026 ready",
     "roadmap-compliant",
+    // v0.4.4 (2026-05-09 U1) — Anthropic Dreams Research Preview
+    // substrate anchor. Dreams API is Research Preview behind a
+    // Request-access form; mnemo ships NO Anthropic-API adapter
+    // today. The README paragraph is substrate-level interop only.
+    // Block adapter-overclaim drift before it ships:
+    "Dreams replacement",
+    "dream-compatible",
+    "Dreams-ready",
+    "Dreams competitor",
+    "curator killer",
+    // v0.4.4 (2026-05-09 U2) — ARGUS provenance composition anchor.
+    // ARGUS is a research artifact (arXiv 2605.03378), not a spec
+    // and not a product. mnemo's HMAC envelope chain is a
+    // *write-side* complement, not a guarantee against any class of
+    // injection by construction. Block compositional-security
+    // overclaim drift:
+    "prompt-injection-proof",
+    "provenance-guaranteed",
+    "ARGUS-compliant",
+    "injection-resistant by construction",
 ];
 
 #[test]

--- a/crates/mnemo-cli/tests/research_doc_argus_present.rs
+++ b/crates/mnemo-cli/tests/research_doc_argus_present.rs
@@ -1,0 +1,43 @@
+//! v0.4.4 (2026-05-09 U2) — `docs/research/argus-2605.03378.md`
+//! survival test. Cheap drift guard: the research-anchor doc must
+//! exist and carry both the arXiv URL and the *composition anchor*
+//! disclaimer so a future operator can find the layering rationale
+//! fast without re-reading the paper.
+
+use std::path::Path;
+
+const DOC_PATH: &str = "docs/research/argus-2605.03378.md";
+const ARXIV_URL: &str = "https://arxiv.org/abs/2605.03378";
+const COMPOSITION_ANCHOR_MARKER: &str = "Composition anchor, not a compliance claim";
+
+#[test]
+fn argus_research_doc_exists_and_carries_arxiv_url() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(DOC_PATH);
+    let body = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!("{DOC_PATH} must exist as the ARGUS research-anchor: {e}");
+    });
+    assert!(
+        body.contains(ARXIV_URL),
+        "{DOC_PATH} must keep the arXiv 2605.03378 URL ({ARXIV_URL}) — \
+         removing it would leave the doc unanchored to the source paper."
+    );
+}
+
+#[test]
+fn argus_research_doc_carries_composition_anchor_disclaimer() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(DOC_PATH);
+    let body = std::fs::read_to_string(&path).expect("argus research doc readable");
+    assert!(
+        body.contains(COMPOSITION_ANCHOR_MARKER),
+        "{DOC_PATH} must carry the literal phrase \
+         `{COMPOSITION_ANCHOR_MARKER}` — this is the standing rule \
+         against compositional-security overclaim. Removing it would \
+         slide the doc into compliance-claim territory."
+    );
+}

--- a/docs/comparisons/anthropic-dreams.md
+++ b/docs/comparisons/anthropic-dreams.md
@@ -1,0 +1,117 @@
+# mnemo vs Anthropic Dreams — substrate vs curator
+
+> Living doc, last updated 2026-05-09. Companion to
+> [`cloudflare-agent-memory.md`](cloudflare-agent-memory.md) (memory store comparison)
+> and [`cloudflare-project-think.md`](cloudflare-project-think.md) (runtime layer
+> comparison). Where those docs ask "where does memory live?" and "where does
+> the agent loop run?", this doc asks the upstream question: "who decides what
+> to keep, what to forget, and what to consolidate — and where does the
+> chosen state durably land?"
+
+## Status — Research Preview
+
+[Anthropic Dreams](https://platform.claude.com/docs/en/managed-agents/dreams)
+is a **Research Preview** feature behind a Request-access form (verified
+2026-05-09). The companion [Routines](https://code.claude.com/docs/en/routines)
+doc describes the long-horizon agents that consume curated memory. The
+public docs page is the only authoritative interface today.
+
+**This doc is a substrate-anchor, not an integration claim.** mnemo does
+not today ship an Anthropic-API adapter. A `mnemo-dreams` adapter crate
+is plausible if/when the API exits Research Preview, but is explicitly
+NOT in scope for v0.4.x. Today's surface is documentation that records
+the layering rationale so an operator evaluating both can see they are
+complementary, not substitute.
+
+## What Dreams does
+
+Per the Anthropic docs page tagline: "Let Claude reflect on past
+sessions to curate an agent's memory and surface new insights." The
+Research Preview describes Dreams as a *curator* — a managed feature
+that reflects over an existing memory store and produces curated
+items: consolidated, forgotten, re-ranked, or annotated. The page does
+not define a new wire protocol; it describes a curator that reads and
+writes memory items through whatever substrate the agent already uses.
+
+The companion Routines doc describes the consumers: long-horizon agents
+whose continued operation benefits from curated memory across many
+sessions.
+
+## What mnemo does
+
+mnemo is the substrate layer beneath such a curator. Its surfaces:
+
+- **REMEMBER / RECALL / FORGET / SHARE** — the four primitives a curator
+  reads and writes through. REMEMBER carries explicit metadata
+  (importance, decay function, source, scope); RECALL carries hybrid
+  scoring + provenance receipts; FORGET carries five strategies
+  (`SoftDelete` / `HardDelete` / `Decay` / `Consolidation` / `Archive`)
+  matching curator-action shapes; SHARE carries cross-agent ACL +
+  delegation chains.
+- **HMAC envelope chain** — every read returns an HMAC-SHA256
+  provenance receipt verifiable offline; every write extends a
+  per-agent chain whose `verify` tool reconstructs the full lineage.
+- **AES-256-GCM at-rest content encryption** via `MNEMO_ENCRYPTION_KEY`,
+  with operator-held keystore.
+- **Bitemporal graph layer** (`mnemo-graph`) — `valid_from` /
+  `valid_to` (fact validity) plus `recorded_at` (system clock).
+  `graph_expand(seed, depth, as_of)` walks the graph at any point in
+  time, which is exactly the shape a curator's "what did the agent
+  know on day N?" reflection needs.
+- **Decay-curve score lane** + cognitive-forgetting strategies — the
+  primitives a curator's forget-policy chooses among, rather than
+  hard-coding any one schedule.
+
+## Layering — curator action ↔ mnemo primitive
+
+| Dreams (curator action) | mnemo (substrate primitive) | Notes |
+|---|---|---|
+| Reflect over past N sessions | RECALL with `as_of` + thread filters | Bitemporal graph + point-in-time recall is what makes this efficient at depth. |
+| Promote / consolidate insights | REMEMBER with `consolidation_state = "consolidated"` + decay-function override | Consolidation is a first-class state in mnemo's record model, not a side-effect of write order. |
+| Demote / forget noise | FORGET with strategy `Decay` or `SoftDelete` (chain preserved) or `HardDelete` (PII redaction with audit-trail) | Five forget strategies cover the curator-policy space without bias. |
+| Re-rank by re-evaluation | RECALL with `hybrid_weights` + custom `rrf_k` | Curator's re-rank policy maps to a tuned RRF across vector + BM25 + decay + recency. |
+| Surface new insights via cross-session linkage | mnemo-graph relations + `graph_expand` traversal | Cross-session linkage lives in the typed-edge layer, not buried in unstructured text. |
+| Audit what was curated and when | Envelope chain + `mnemo verify` | Every curator action chains into the HMAC ledger; an auditor can reconstruct the full curation history months later, offline. |
+
+## Explicit non-overlap
+
+Dreams owns the *what to curate* policy: which sessions to reflect
+over, which insights to surface, what consolidation rule to apply,
+how often to run. mnemo owns the *how to durably store with audit
+trail*: HMAC chain integrity, AES-256-GCM at-rest encryption,
+bitemporal graph, point-in-time recall, offline provenance receipts,
+DPDPA / GDPR subject erasure with audit preservation.
+
+If Dreams chooses to consolidate three memories into one, mnemo records
+that consolidation as a chained event with the curator identity in
+the envelope, so a future auditor can reconstruct the decision.
+mnemo's job is not to decide *whether* the consolidation was correct;
+that's the curator's job. mnemo's job is to make the audit trail
+verifiable offline.
+
+## Future — `mnemo-dreams` adapter
+
+If/when the Dreams API exits Research Preview and ships a public
+read/write surface, a `mnemo-dreams` adapter crate becomes plausible.
+The adapter would expose mnemo's RECALL / REMEMBER / FORGET to a
+Dreams curator the way `mnemo-cma` (v0.4.1) bridges the Anthropic
+CMA-Memory beta filesystem into the mnemo HMAC chain. **This crate is
+explicitly NOT on the v0.4.4 backlog today** — the API surface to bind
+against is not yet public.
+
+Operators wanting to experiment ahead of GA can pre-stage by:
+
+1. Running mnemo with the existing four primitives + envelope chain.
+2. Manually issuing curator-style operations (consolidations, decay
+   tweaks, re-ranks) through the existing CLI / SDK while Dreams is
+   in Research Preview.
+3. When the API ships, a thin adapter crate translates Dreams calls
+   into the operations they were already manually issuing.
+
+## Sources
+
+- Anthropic Dreams Research Preview docs — https://platform.claude.com/docs/en/managed-agents/dreams (surfaced at Code w/ Claude SF, 2026-05-06; verified live 2026-05-09)
+- Anthropic Routines doc — https://code.claude.com/docs/en/routines (companion long-horizon agent context, 2026-05-06)
+- mnemo memory-store comparison: [`cloudflare-agent-memory.md`](cloudflare-agent-memory.md)
+- mnemo runtime-layer comparison: [`cloudflare-project-think.md`](cloudflare-project-think.md)
+- v0.4.4 carry list: [`../../CHANGELOG.md`](../../CHANGELOG.md) `[Unreleased]` § *Parked for v0.4.4 backlog* (no `mnemo-dreams` entry — explicitly out of scope)

--- a/docs/comparisons/cloudflare-agent-memory.md
+++ b/docs/comparisons/cloudflare-agent-memory.md
@@ -156,6 +156,44 @@ The same axis that this comparison's S3 (chain audit replay) and S5
 (sovereignty round-trip) rows test is what an applied-agent-layer
 deployment of this scale ultimately reaches for.
 
+## Read-side composition: ARGUS provenance auditing (2026-05-09)
+
+> *Composition anchor, not a compliance claim.* This section records
+> a complementary research artifact whose read-side analysis pairs
+> naturally with mnemo's write-side envelope chain. mnemo does NOT
+> claim to be "ARGUS-compliant" or "prompt-injection-proof" — those
+> phrasings are explicitly banned by `tests/readme_no_marketing_phrases.rs`.
+
+[ARGUS](https://arxiv.org/abs/2605.03378) (arXiv 2605.03378, submitted
+2026-05-05) introduces a *read-side* decision-auditing model for
+LLM-based agents. The paper traces each model decision back to the
+context items that influenced it, with explicit handling for
+context-aware prompt-injection adversaries. The audit runs
+post-hoc — given a recorded decision and the provenance of the
+context that fed it, ARGUS reconstructs the influence path and
+flags the decision when context-aware injection is suspected.
+
+mnemo provides the *write-side* complement that ARGUS-style auditing
+needs underneath:
+
+| Audit need | mnemo surface |
+|---|---|
+| Reconstruct what context each decision saw | RECALL with `with_provenance=true` returns an HMAC-SHA256 receipt naming the cited records; offline-verifiable months later |
+| Reconstruct exact context state at decision time | Bitemporal graph + `as_of` point-in-time queries replay the substrate as it existed at decision time |
+| Distinguish trusted from poisoned context | `quarantine_reason` field + memory-poisoning detector quarantines flagged content; envelope chain records who quarantined and when |
+| Detect context-aware injection adversaries post-hoc | Append-only audit log + envelope chain integrity verification (`mnemo verify`) provides the immutable substrate ARGUS reads from |
+| Write-side authorship forensics | Per-record `source_type` + `created_by` + envelope chain identifies write-side actor on every memory record |
+
+The two layers compose without coupling: mnemo records the substrate
+honestly and offline-verifiably, ARGUS audits the read path against
+that substrate. Neither replaces the other; together they cover both
+sides of the provenance question. See [`../research/argus-2605.03378.md`](../research/argus-2605.03378.md)
+for a longer research-anchor note.
+
+**Explicit non-overlap:** mnemo does not implement ARGUS's read-side
+auditing model. mnemo's job is to make the substrate auditable; the
+read-side audit policy is a separate layer.
+
 ## v0.4.3 plan
 
 The `mnemo-bench-cf` crate (deferred from the 2026-05-02 prompt) will:

--- a/docs/comparisons/cloudflare-project-think.md
+++ b/docs/comparisons/cloudflare-project-think.md
@@ -130,6 +130,14 @@ both as the offline-auditable storage substrate. See the four-priority
 mapping in [`../src/integrations/mcp-server.md`](../src/integrations/mcp-server.md)
 §"MCP 2026 Roadmap alignment".
 
+Anthropic's [Dreams Research Preview](https://platform.claude.com/docs/en/managed-agents/dreams)
+(2026-05-06) extends this stack with a *curator* layer on top: Project
+Think runs the durable loop, the MCP 2026 Roadmap defines the protocol
+direction, Dreams decides what to keep / forget / consolidate, and
+mnemo records the substrate state with offline-verifiable audit. See
+[`anthropic-dreams.md`](anthropic-dreams.md) for the curator-action ↔
+substrate-primitive layering table.
+
 ## Sources
 
 - Cloudflare Project Think announcement — https://blog.cloudflare.com/project-think/ (2026-05-04)

--- a/docs/research/argus-2605.03378.md
+++ b/docs/research/argus-2605.03378.md
@@ -1,0 +1,95 @@
+# ARGUS 2605.03378 — research-anchor note
+
+> Recorded 2026-05-09. **Composition anchor, not a compliance claim.**
+> ARGUS is an external research artifact, not a spec and not a
+> product. mnemo claims neither implementation of ARGUS nor any
+> form of "ARGUS-compliance" — those phrasings are explicitly
+> banned by `tests/readme_no_marketing_phrases.rs`. This note exists
+> so a future contributor can find the layering rationale fast
+> without re-reading the paper.
+
+## Citation
+
+- **Paper:** "Provenance-Aware Decision Auditing for Context-Aware
+  Prompt Injection" (full title in this paragraph only).
+- **arXiv:** [2605.03378](https://arxiv.org/abs/2605.03378)
+- **Submitted:** 2026-05-05 (4 days old at the time of this anchor)
+
+## What ARGUS does
+
+ARGUS is a *read-side* decision-auditing model. Given:
+
+1. A recorded LLM decision (the model's output for some prompt /
+   tool-call / response).
+2. The provenance of every context item that fed the prompt
+   (where the item came from, who wrote it, when it was retrieved).
+
+ARGUS reconstructs the influence graph from context items to the
+decision and flags decisions where the influence shape is consistent
+with **context-aware prompt-injection adversaries**: an attacker who
+knew the agent's retrieval policy and seeded the substrate with items
+designed to be retrieved at the right moment to nudge a specific
+decision.
+
+The paper's contribution is the audit *model* — the formal influence
+shape of context-aware injection — and a methodology for applying it
+post-hoc to recorded decisions. It does not propose a new wire
+protocol or a new substrate; it assumes the substrate already records
+provenance for every context item.
+
+## Where mnemo fits
+
+mnemo is the substrate the audit reads from. The pairing is natural
+because mnemo's existing surfaces already produce the inputs ARGUS-style
+auditing needs:
+
+- **Per-record provenance.** Every memory record carries
+  `source_type` + `created_by` + `consolidation_state`, and every
+  RECALL returns an HMAC-SHA256 provenance receipt naming the cited
+  records.
+- **Bitemporal context replay.** `as_of` point-in-time queries +
+  bitemporal graph traversal reconstruct the substrate state at the
+  exact moment of the audited decision.
+- **Quarantine state.** `quarantined` + `quarantine_reason` separate
+  flagged-but-retained context from healthy context — useful when
+  ARGUS is replaying a decision and needs to know which retrieved
+  items were already suspect at retrieval time.
+- **Append-only audit log.** PostgreSQL trigger
+  (`prevent_event_modification`) enforces the substrate's immutability
+  at the schema level, which is what makes the audit trustworthy
+  months later.
+- **Offline verification.** `mnemo verify` reconstructs the envelope
+  chain without contacting any cloud account — the substrate is
+  audit-trustworthy even when the original deployment is gone.
+
+## What this note is NOT
+
+- **Not an ARGUS implementation.** mnemo does not implement the
+  ARGUS audit model. The read-side auditing logic lives elsewhere
+  (a future ARGUS reference implementation, an internal SOC tool,
+  or whatever the operator chooses).
+- **Not a compliance claim.** Compositional security claims
+  ("prompt-injection-proof", "provenance-guaranteed",
+  "injection-resistant by construction") are explicitly banned by
+  the README marketing-phrase test extension that landed alongside
+  this note (2026-05-09 U2). mnemo's job is the substrate; ARGUS's
+  job is the audit; together they cover both sides — neither
+  guarantees end-to-end safety alone.
+- **Not a benchmark.** No bench harness is implied. If a future
+  v0.5.x ships an ARGUS-replay reference test corpus, that's a
+  separate row.
+
+## Cross-references
+
+- Substrate-side comparison: [`../comparisons/cloudflare-agent-memory.md`](../comparisons/cloudflare-agent-memory.md)
+  § *Read-side composition: ARGUS provenance auditing (2026-05-09)*
+- Memory-curation substrate anchor: [`../comparisons/anthropic-dreams.md`](../comparisons/anthropic-dreams.md)
+  (companion 2026-05-09 row — both anchor mnemo as substrate
+  layer beneath external read/write models)
+- v0.4.4 carry list: [`../../CHANGELOG.md`](../../CHANGELOG.md)
+  `[Unreleased]` block (no `mnemo-argus` entry — ARGUS-aware audit
+  tooling is not on the v0.4.4 backlog)
+
+## Sources
+
+- arXiv 2605.03378 — https://arxiv.org/abs/2605.03378 (submitted 2026-05-05)


### PR DESCRIPTION
## Summary

Two S-effort docs/test rows for v0.4.4 `[Unreleased]`. **Both cite fresh ≤7d primary URLs** from Anthropic's Code w/ Claude SF event (2026-05-06) and arXiv (2026-05-05). **Workspace version stays at `0.4.3`** — this PR populates `[Unreleased]` without cutting v0.4.4.

### U1 — Anthropic Dreams Research Preview substrate anchor

The [Dreams Research Preview docs page](https://platform.claude.com/docs/en/managed-agents/dreams) (surfaced 2026-05-06 at Code w/ Claude SF, 3 days old at land-time) describes a managed-agent curator that "reflects on past sessions to curate an agent's memory and surface new insights." Its companion [Routines doc](https://code.claude.com/docs/en/routines) describes the long-horizon agents that consume curated memory.

- README `### Memory curation interop (Dreams, Routines, and substrate primitives)` sub-section inside Key Features.
- New `docs/comparisons/anthropic-dreams.md` with curator-action ↔ substrate-primitive layering table; explicit non-overlap callout (Dreams owns *what to curate*, mnemo owns *how to durably store with audit trail*); explicit "future" section noting a `mnemo-dreams` adapter crate is plausible if/when the API exits Research Preview but is **NOT in scope for v0.4.x**.
- One-sentence cross-link in `docs/comparisons/cloudflare-project-think.md` noting Project Think (runtime) + MCP 2026 Roadmap (protocol) + Dreams (curator) together describe the runtime + protocol + curator picture, with mnemo as the offline-auditable substrate underneath all three.

**Honest framing:** the Dreams API is Research Preview behind a Request-access form; **mnemo does NOT today ship an Anthropic-API adapter**. Today's anchor is substrate-level interop documentation, not integration. The README paragraph carries an explicit `Research Preview` disclaimer, enforced by `tests/readme_dreams_link.rs::dreams_paragraph_carries_research_preview_honesty_disclaimer`.

Two new tests:
- `tests/readme_dreams_link.rs` (4 functions) — Dreams primary-source URL + heading + comparison-doc-link + Research Preview disclaimer survival.
- `tests/readme_no_marketing_phrases.rs` banlist extended with five Dreams overclaim phrasings: `Dreams replacement`, `dream-compatible`, `Dreams-ready`, `Dreams competitor`, `curator killer`.

### U2 — ARGUS provenance composition anchor

[arXiv 2605.03378](https://arxiv.org/abs/2605.03378) (provenance-aware decision auditing for context-aware prompt injection, submitted 2026-05-05, 4 days old at land-time) introduces a *read-side* decision-auditing model that traces each model decision back to context items that influenced it, with explicit handling for context-aware prompt-injection adversaries. mnemo's HMAC-keyed envelope chain + REMEMBER/RECALL/FORGET/SHARE primitive provenance is the *write-side* complement.

- `docs/comparisons/cloudflare-agent-memory.md` gains a `## Read-side composition: ARGUS provenance auditing (2026-05-09)` section with a five-row audit-need ↔ mnemo-surface table, explicit non-overlap callout, and composition-anchor framing ("not a compliance claim").
- New `docs/research/argus-2605.03378.md` short research-anchor doc walking through what ARGUS does, where mnemo fits, and what this note is **explicitly NOT** (not an implementation, not a compliance claim, not a benchmark).

**Honest framing:** ARGUS is a research artifact, not a spec and not a product. mnemo claims neither implementation of ARGUS nor any form of "ARGUS-compliance." The two layers compose without coupling.

Two new tests:
- `tests/research_doc_argus_present.rs` (2 functions) — arXiv URL + composition-anchor disclaimer survival.
- `tests/readme_no_marketing_phrases.rs` banlist extended with four compositional-security overclaim phrasings: `prompt-injection-proof`, `provenance-guaranteed`, `ARGUS-compliant`, `injection-resistant by construction`.

### CHANGELOG `[Unreleased]` updates

Both U1 and U2 added under existing Added / Documentation / Tests sub-blocks. The `### Landing trace (2026-05-06)` SHA pointer from PR #77 stays in place; tomorrow's prompt would add a fresh `### Landing trace (2026-05-10)` sub-block referencing this PR's commit. The `changelog_has_landing_trace_section` regression test still passes (existing 2802616 SHA satisfies the `[0-9a-f]{7,40}` requirement).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --workspace --exclude mnemo-python -- -D warnings` clean (CI invocation)
- [x] `cargo test --workspace --exclude mnemo-python --no-fail-fast` — **356 passed**, 0 failed, 5 ignored (was 350 on PR #77; +6 from new tests)
- [x] All 4 new `readme_dreams_link` tests green
- [x] All 2 new `research_doc_argus_present` tests green
- [x] Extended `readme_no_marketing_phrases` banlist green (rejects 9 new phrases without false-positives in current README)
- [x] CHANGELOG structural tests still green: `changelog_has_unreleased_section` ×2 + `changelog_has_landing_trace_section` ×1

## Mannsetu life-safety note

The 2026-05-09 daily prompt's life-safety banner flags mannsetu `/crisis` as RED on Day 3 SEV-1. This PR is **operator-parallelizable**: it touches only mnemo's own files (no shared infrastructure with mannsetu) and ships docs + tests only — no Rust runtime change, no SDK touch, no breaking change. A teammate on the mannsetu hotfix R4 (15-min GoDaddy 301-forwarding rule) is unaffected by this merge.

## Sources

- https://platform.claude.com/docs/en/managed-agents/dreams (Anthropic Dreams Research Preview, surfaced 2026-05-06 — U1 primary URL)
- https://code.claude.com/docs/en/routines (Anthropic Routines, companion long-horizon agent context — U1)
- https://arxiv.org/abs/2605.03378 (ARGUS provenance-aware decision auditing, submitted 2026-05-05 — U2 primary URL)
- https://github.com/sattyamjjain/mnemo/commit/280261639837d9cf84e387347b2732c162c93bec (PR #76 Landing trace pointer kept in `[Unreleased]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)