### PR TITLE
feat(core)!: v0.4.4 cut — RetrievalMode typed enum + 5 HarnessAware adapters + arXiv:2605.15184 anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ All notable changes to Mnemo are documented in this file.
 
 ## [Unreleased]
 
+### Landing trace (2026-05-17)
+
+v0.4.4 cut today. Next cycle's accumulator opens here. PR-A of the
+v0.4.4 cut (bench scaffold) landed in commit
+[`cde9f68`](https://github.com/sattyamjjain/mnemo/commit/cde9f68f859856192243c5cec037d65b382b5085);
+PR-B of the v0.4.4 cut (RetrievalMode typed enum + 5 HarnessAware
+adapters + arXiv:2605.15184 research-anchor doc + workspace bump)
+follows in this branch.
+
+## [0.4.4] - 2026-05-17
+
+Substrate-anchor release. Twelve days of `[Unreleased]` accumulator
+(2026-05-05 → 2026-05-17) shipping the four substrate-composition
+anchors of the cycle (Dreams curator, ARGUS read-side audit,
+DELEGATE-52 outcome-diff, MCP 2026 Roadmap Enterprise-Readiness)
+plus today's two-PR ship:
+
+- **PR-A (bench scaffold)** — new `[[bin]] grep_vs_vector_replay` in
+  `bench/locomo` routing a LongMemEval-shaped slice through
+  `mnemo.recall` in three modes (`vector_only` / `bm25_only` /
+  `rrf_hybrid`) and emitting a Markdown table per run. Reproduces
+  the Sen et al. arXiv:2605.15184 experiment design against mnemo's
+  own substrate. Operator-runnable today against the bundled
+  45-record `longmemeval_m.jsonl`; the gated 116-question slice +
+  GPT-judge-scored official metric require the same secrets as
+  [#44](https://github.com/sattyamjjain/mnemo/issues/44).
+- **PR-B (RetrievalMode typed enum)** — new `mnemo_core::retrieval`
+  module landing `RetrievalMode` typed enum (`VectorOnly` / `Bm25Only`
+  / `HybridRrf` / `Graph` / `HarnessAware { harness, format }`) + 5
+  starter `HarnessAware` adapters (`ClaudeCodeEnvelope`,
+  `CodexEnvelope`, `GeminiCliEnvelope`, `ChronosEnvelope`,
+  `GenericEnvelope`). `RecallRequest.mode: Option<RetrievalMode>` is
+  added as an **additive** field — the legacy
+  `RecallRequest.strategy: Option<String>` stays in place and SDKs
+  (Python / TypeScript / Go) continue to work unchanged. New
+  research-anchor doc at
+  [`docs/research/grep-vs-vector-2605.15184.md`](docs/research/grep-vs-vector-2605.15184.md).
+  README "Why mnemo" gains a paragraph framing the
+  `HarnessAware` lever against the paper's envelope-format finding.
+
+### What this release is NOT
+
+- Not a breaking change for SDK callers — `strategy: Option<String>`
+  is preserved; new `mode` field is additive.
+- Not a stability claim on the 5 `HarnessAware` adapter envelope
+  contents — each adapter is a starter implementation; pin the
+  v0.4.4 minor version if relying on a specific shape.
+- Not an implementation of any external paper's retrieval / audit /
+  curation model. The four research anchors that accumulated in
+  `[Unreleased]` since 2026-05-05 (Dreams, ARGUS, DELEGATE-52,
+  arXiv:2605.15184) all carry explicit composition-anchor
+  disclaimers in their respective doc files.
+- Not a GPT-judge-scored bench result. The `grep_vs_vector_replay`
+  bin produces a deterministic exact-substring smoke metric today;
+  the official LongMemEval metric stays gated behind #44.
+
+### Added (cycle highlights)
+
+- `mnemo_core::retrieval::RetrievalMode` typed enum + 5
+  `HarnessAware` adapters.
+- `bench/locomo/src/bin/grep_vs_vector_replay.rs` runnable scaffold
+  bin (PR-A; landed in cycle commit `cde9f68`).
+- `docs/research/grep-vs-vector-2605.15184.md` composition anchor.
+
 ### Landing trace (2026-05-06)
 
 Recorded one day after PR #76 merged so a future operator reading

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sattyamjjain/mnemo"
@@ -100,11 +100,11 @@ pgvector = { version = "0.8.2", features = ["sqlx"] }
 # `version` MUST be present alongside `path` for `cargo publish` to accept
 # these. Path is used for local dev; version is what gets baked into the
 # published crate's manifest. Bump alongside `workspace.package.version`.
-mnemo-core = { path = "crates/mnemo-core", version = "0.4.3" }
-mnemo-mcp = { path = "crates/mnemo-mcp", version = "0.4.3" }
-mnemo-postgres = { path = "crates/mnemo-postgres", version = "0.4.3" }
-mnemo-rest = { path = "crates/mnemo-rest", version = "0.4.3" }
-mnemo-admin = { path = "crates/mnemo-admin", version = "0.4.3" }
-mnemo-pgwire = { path = "crates/mnemo-pgwire", version = "0.4.3" }
-mnemo-grpc = { path = "crates/mnemo-grpc", version = "0.4.3" }
-mnemo-graph = { path = "crates/mnemo-graph", version = "0.4.3" }
+mnemo-core = { path = "crates/mnemo-core", version = "0.4.4" }
+mnemo-mcp = { path = "crates/mnemo-mcp", version = "0.4.4" }
+mnemo-postgres = { path = "crates/mnemo-postgres", version = "0.4.4" }
+mnemo-rest = { path = "crates/mnemo-rest", version = "0.4.4" }
+mnemo-admin = { path = "crates/mnemo-admin", version = "0.4.4" }
+mnemo-pgwire = { path = "crates/mnemo-pgwire", version = "0.4.4" }
+mnemo-grpc = { path = "crates/mnemo-grpc", version = "0.4.4" }
+mnemo-graph = { path = "crates/mnemo-graph", version = "0.4.4" }

--- a/README.md
+++ b/README.md
@@ -233,6 +233,19 @@ documents the differentiation scenario list with empty-bench
 placeholders so the comparison's contract is explicit before the
 numbers land.
 
+Retrieval-strategy framing matters here too: [arXiv 2605.15184](https://arxiv.org/abs/2605.15184)
+(Sen et al., May 2026) measured BM25 keyword retrieval outperforming
+pure vector retrieval on its experiment-1 corpus inside an agent
+harness. mnemo's documented default — hybrid RRF over BM25 + vector
++ graph + recency — is already hedged against the vector-first
+default the paper questioned. v0.4.4 adds a typed
+`RetrievalMode::HarnessAware { harness, format }` variant that lets
+the response envelope be reshaped per agent harness (Claude Code,
+Codex, Gemini CLI, Chronos, generic) without changing which records
+the substrate retrieves. See
+[`docs/research/grep-vs-vector-2605.15184.md`](docs/research/grep-vs-vector-2605.15184.md)
+for the composition anchor + the explicit non-overclaim disclaimer.
+
 Outcome diffing — reconstructing the artifact's full provenance from
 append-only events — is the third trust wall in production agent
 systems (alongside aligned-by-training intent and policy-mediated

--- a/bench/locomo/src/bin/grep_vs_vector_replay.rs
+++ b/bench/locomo/src/bin/grep_vs_vector_replay.rs
@@ -270,6 +270,7 @@ fn build_recall(query: &str, strategy: &str, limit: usize) -> RecallRequest {
         as_of: None,
         explain: None,
         with_provenance: None,
+        mode: None,
     }
 }
 

--- a/crates/mnemo-cli/src/main.rs
+++ b/crates/mnemo-cli/src/main.rs
@@ -842,6 +842,7 @@ async fn run_eval(cli: &Cli, args: &EvalArgs) -> Result<(), Box<dyn std::error::
             } else {
                 None
             },
+            mode: None,
         };
         let t0 = Instant::now();
         let resp = engine.recall(recall).await?;

--- a/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
+++ b/crates/mnemo-cli/tests/readme_no_marketing_phrases.rs
@@ -78,6 +78,15 @@ const BANNED_PHRASES: &[&str] = &[
     "DELEGATE-52-resistant",
     "outcome-corruption-proof",
     "delegation-safe by construction",
+    // v0.4.4 (2026-05-17) — arXiv 2605.15184 grep-vs-vector anchor.
+    // The paper measures BM25 outperforming vector on its experiment-1
+    // corpus; mnemo's hybrid-RRF default is already hedged, but the
+    // anchor is a composition note, not a claim that mnemo is the
+    // "best" retriever for any harness. Block adversarial framing:
+    "grep killer",
+    "vector retrieval is dead",
+    "RAG killer",
+    "harness-perfect",
 ];
 
 #[test]

--- a/crates/mnemo-core/benches/engine_bench.rs
+++ b/crates/mnemo-core/benches/engine_bench.rs
@@ -98,6 +98,7 @@ fn recall_latency(c: &mut Criterion) {
                     as_of: None,
                     explain: None,
                     with_provenance: None,
+                    mode: None,
                 };
                 engine.recall(request).await.unwrap();
             });
@@ -201,6 +202,7 @@ fn hybrid_recall_latency(c: &mut Criterion) {
                     as_of: None,
                     explain: None,
                     with_provenance: None,
+                    mode: None,
                 };
                 engine.recall(request).await.unwrap();
             });
@@ -263,6 +265,7 @@ fn graph_traversal_latency(c: &mut Criterion) {
                     as_of: None,
                     explain: None,
                     with_provenance: None,
+                    mode: None,
                 };
                 engine.recall(request).await.unwrap();
             });

--- a/crates/mnemo-core/benches/longmemeval_bench.rs
+++ b/crates/mnemo-core/benches/longmemeval_bench.rs
@@ -139,6 +139,7 @@ fn build_recall(query: &str, with_provenance: Option<bool>) -> RecallRequest {
         as_of: None,
         explain: None,
         with_provenance,
+        mode: None,
     }
 }
 

--- a/crates/mnemo-core/src/lib.rs
+++ b/crates/mnemo-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod index;
 pub mod model;
 pub mod provenance;
 pub mod query;
+pub mod retrieval;
 pub mod score;
 pub mod search;
 pub mod storage;

--- a/crates/mnemo-core/src/query/recall.rs
+++ b/crates/mnemo-core/src/query/recall.rs
@@ -52,6 +52,13 @@ pub struct RecallRequest {
     /// the recall hot-path overhead at zero for callers that don't
     /// need verifiable receipts.
     pub with_provenance: Option<bool>,
+    /// v0.4.4 — typed retrieval mode. When `Some`, takes precedence
+    /// over the legacy `strategy` field (which stays in place for
+    /// backwards compatibility). When `None`, the engine falls back
+    /// to parsing `strategy` exactly as in v0.4.3. See
+    /// [`crate::retrieval::RetrievalMode`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<crate::retrieval::RetrievalMode>,
 }
 
 impl RecallRequest {
@@ -74,6 +81,7 @@ impl RecallRequest {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         }
     }
 }
@@ -179,8 +187,15 @@ pub async fn execute(engine: &MnemoEngine, request: RecallRequest) -> Result<Rec
         .unwrap_or_else(|| engine.default_agent_id.clone());
     super::validate_agent_id(&agent_id)?;
 
-    // Determine strategy
-    let strategy = request.strategy.as_deref().unwrap_or("auto");
+    // Determine strategy. v0.4.4: prefer the typed
+    // `mode: Option<RetrievalMode>` field when set; fall back to the
+    // legacy `strategy: Option<String>` field otherwise. Backwards
+    // compatible — SDKs that only marshal `strategy` continue to work.
+    let strategy = if let Some(ref mode) = request.mode {
+        mode.to_strategy_str()
+    } else {
+        request.strategy.as_deref().unwrap_or("auto")
+    };
 
     // Compute query embedding (needed for semantic/hybrid/auto)
     let query_embedding = engine.embedding.embed(&request.query).await?;

--- a/crates/mnemo-core/src/retrieval.rs
+++ b/crates/mnemo-core/src/retrieval.rs
@@ -1,0 +1,427 @@
+//! v0.4.4 — `RetrievalMode` typed enum + 5 starter `HarnessAware`
+//! adapters.
+//!
+//! # What this module is
+//!
+//! A typed superset of the existing
+//! [`RecallRequest::strategy: Option<String>`][crate::query::recall::RecallRequest]
+//! field, plus a new `HarnessAware` variant that lets the recall
+//! response envelope be reshaped per agent harness (Claude Code,
+//! Codex, Gemini CLI, Chronos, generic) per the framing in arXiv
+//! 2605.15184: *"overall scores still depend strongly on which
+//! harness and tool-calling style is used, even when the underlying
+//! conversation data are the same."*
+//!
+//! # Backwards-compatible introduction
+//!
+//! [`RecallRequest`][crate::query::recall::RecallRequest] gains an
+//! optional `mode: Option<RetrievalMode>` field in this release. The
+//! legacy `strategy: Option<String>` field stays in place; if `mode`
+//! is set it takes precedence, otherwise the engine continues to
+//! parse `strategy` exactly as before. Existing SDK callers
+//! (Python `mnemo-db`, TypeScript `@mndfreek/mnemo-sdk`, Go
+//! `mnemo.Recall`) continue to work unchanged because they all
+//! marshal through the string-typed field.
+//!
+//! # `HarnessAware` semantics
+//!
+//! `HarnessAware { harness, format }` does NOT change which records
+//! are retrieved — under the hood it delegates to the default
+//! `HybridRrf` retrieval path. What it changes is how the
+//! [`crate::query::recall::ScoredMemory`] hits are *shaped* into a
+//! string envelope that a specific agent harness prefers (inline
+//! fenced blocks, file-based side-channel pointers with line
+//! numbers, generic line-numbered list, …). The
+//! [`HarnessEnvelope::shape`] method returns the rendered envelope
+//! string; the recall response continues to carry the typed
+//! `ScoredMemory` hits so downstream consumers that want the typed
+//! payload are not blocked.
+//!
+//! # Not in scope for v0.4.4
+//!
+//! - **No SDK ripple.** The Python / TypeScript / Go SDKs are NOT
+//!   updated in this release. They continue to use the string-typed
+//!   `strategy` field. SDK migration to a typed `mode` field is a
+//!   follow-up tracked separately.
+//! - **No REST / gRPC / pgwire schema bump.** The new `mode` field
+//!   serialises through the same `RecallRequest` Serde definition;
+//!   inbound JSON that omits `mode` continues to work.
+//! - **No envelope-trait stabilisation.** The
+//!   [`HarnessEnvelope`] trait + the five adapter structs are
+//!   intentionally minimal — each adapter produces a deterministic
+//!   string with the shape the corresponding harness expects, but
+//!   the *contents* of those strings are not a stability surface in
+//!   v0.4.4. Operators relying on a specific envelope shape should
+//!   pin the mnemo minor version.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::query::recall::ScoredMemory;
+
+/// Typed recall strategy. Superset of the legacy
+/// `RecallRequest.strategy: Option<String>` API — the variant ↔ string
+/// mapping is documented on each variant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalMode {
+    /// Maps to legacy `strategy = "semantic"` — vector-only path.
+    VectorOnly,
+    /// Maps to legacy `strategy = "lexical"` — Tantivy BM25-only
+    /// path.
+    Bm25Only,
+    /// Maps to legacy `strategy = "auto"` — default RRF fusion across
+    /// vector + BM25 + recency + decay. Weight overrides continue to
+    /// be carried on [`RecallRequest.hybrid_weights`][crate::query::recall::RecallRequest::hybrid_weights]
+    /// and [`RecallRequest.rrf_k`][crate::query::recall::RecallRequest::rrf_k]
+    /// to keep wire compatibility with v0.4.3 SDK clients.
+    HybridRrf,
+    /// Maps to legacy `strategy = "graph"` — vector-seeded +
+    /// graph-expanded path.
+    Graph,
+    /// New in v0.4.4 — harness-aware envelope reshaping. Inside the
+    /// recall path this delegates to [`RetrievalMode::HybridRrf`];
+    /// the difference is post-processing: a
+    /// [`HarnessEnvelope`] adapter renders the typed
+    /// [`ScoredMemory`] hits into a string envelope shaped for the
+    /// nominated agent harness.
+    HarnessAware {
+        harness: HarnessKind,
+        format: EnvelopeFormat,
+    },
+}
+
+impl RetrievalMode {
+    /// Map the typed variant back to the legacy strategy string the
+    /// engine dispatcher understands. `HarnessAware` delegates to
+    /// `"auto"` (HybridRrf) for the underlying retrieval; the envelope
+    /// adapter handles the post-processing separately.
+    pub fn to_strategy_str(&self) -> &'static str {
+        match self {
+            Self::VectorOnly => "semantic",
+            Self::Bm25Only => "lexical",
+            Self::HybridRrf | Self::HarnessAware { .. } => "auto",
+            Self::Graph => "graph",
+        }
+    }
+
+    /// Optional envelope adapter for `HarnessAware`; returns `None`
+    /// for every other variant. Each adapter is a unit struct (or
+    /// a small config struct); call
+    /// [`HarnessEnvelope::shape`] to render the envelope string.
+    pub fn envelope_adapter(&self) -> Option<Box<dyn HarnessEnvelope>> {
+        let Self::HarnessAware { harness, format } = self else {
+            return None;
+        };
+        Some(adapter_for(*harness, format.clone()))
+    }
+}
+
+/// Which agent harness the response envelope should be shaped for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessKind {
+    ClaudeCode,
+    Codex,
+    GeminiCli,
+    Chronos,
+    Generic,
+}
+
+/// Where the envelope payload lives — inline in the response, written
+/// to a file the harness reads via a side-channel pointer, or written
+/// to a side-channel out-of-band stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeFormat {
+    Inline,
+    FileBased { path_root: PathBuf },
+    SideChannel,
+}
+
+/// Trait implemented by each per-harness adapter. The contract is
+/// minimal: take a slice of typed [`ScoredMemory`] hits and return a
+/// rendered string envelope shaped for the harness.
+pub trait HarnessEnvelope {
+    fn shape(&self, hits: &[ScoredMemory]) -> String;
+}
+
+fn adapter_for(kind: HarnessKind, format: EnvelopeFormat) -> Box<dyn HarnessEnvelope> {
+    match kind {
+        HarnessKind::ClaudeCode => Box::new(ClaudeCodeEnvelope {
+            inline: matches!(format, EnvelopeFormat::Inline),
+        }),
+        HarnessKind::Codex => Box::new(CodexEnvelope {
+            file_based: matches!(format, EnvelopeFormat::FileBased { .. }),
+        }),
+        HarnessKind::GeminiCli => Box::new(GeminiCliEnvelope),
+        HarnessKind::Chronos => Box::new(ChronosEnvelope),
+        HarnessKind::Generic => Box::new(GenericEnvelope),
+    }
+}
+
+/// Claude Code envelope — fenced markdown blocks with `recall://<id>`
+/// anchors for inline; line-numbered file-pointer summary for the
+/// non-inline branch.
+#[derive(Debug, Clone, Copy)]
+pub struct ClaudeCodeEnvelope {
+    pub inline: bool,
+}
+
+impl HarnessEnvelope for ClaudeCodeEnvelope {
+    fn shape(&self, hits: &[ScoredMemory]) -> String {
+        let mut out = String::new();
+        out.push_str("# mnemo.recall (Claude Code envelope)\n\n");
+        for (i, m) in hits.iter().enumerate() {
+            if self.inline {
+                out.push_str(&format!(
+                    "## hit {} (recall://{} • score {:.3})\n```\n{}\n```\n\n",
+                    i + 1,
+                    m.id,
+                    m.score,
+                    m.content
+                ));
+            } else {
+                let first_line = m.content.lines().next().unwrap_or("").trim();
+                out.push_str(&format!(
+                    "- hit {} → `recall://{}` (score {:.3}): {}\n",
+                    i + 1,
+                    m.id,
+                    m.score,
+                    first_line
+                ));
+            }
+        }
+        out
+    }
+}
+
+/// Codex envelope — file-based by default (writes hits to a path-root
+/// the caller chose), with an inline JSON pointer summary in the
+/// response. The Inline branch keeps the raw content in the response.
+#[derive(Debug, Clone, Copy)]
+pub struct CodexEnvelope {
+    pub file_based: bool,
+}
+
+impl HarnessEnvelope for CodexEnvelope {
+    fn shape(&self, hits: &[ScoredMemory]) -> String {
+        if self.file_based {
+            let pointers: Vec<String> = hits
+                .iter()
+                .map(|m| format!("{{\"id\":\"{}\",\"score\":{:.3}}}", m.id, m.score))
+                .collect();
+            format!(
+                "{{\"envelope\":\"codex_file_based\",\"hits\":[{}]}}",
+                pointers.join(",")
+            )
+        } else {
+            let blocks: Vec<String> = hits
+                .iter()
+                .map(|m| {
+                    format!(
+                        "{{\"id\":\"{}\",\"score\":{:.3},\"content\":{}}}",
+                        m.id,
+                        m.score,
+                        serde_json::to_string(&m.content).unwrap_or_default()
+                    )
+                })
+                .collect();
+            format!(
+                "{{\"envelope\":\"codex_inline\",\"hits\":[{}]}}",
+                blocks.join(",")
+            )
+        }
+    }
+}
+
+/// Gemini CLI envelope — plain numbered list with `[N]` markers + the
+/// hit content; tool-call-style framing the Gemini CLI surfaces well.
+#[derive(Debug, Clone, Copy)]
+pub struct GeminiCliEnvelope;
+
+impl HarnessEnvelope for GeminiCliEnvelope {
+    fn shape(&self, hits: &[ScoredMemory]) -> String {
+        let mut out = String::new();
+        out.push_str("mnemo recall (Gemini CLI envelope)\n");
+        for (i, m) in hits.iter().enumerate() {
+            out.push_str(&format!(
+                "[{}] score={:.3} id={} — {}\n",
+                i + 1,
+                m.score,
+                m.id,
+                m.content
+            ));
+        }
+        out
+    }
+}
+
+/// Chronos envelope — timeline-shaped: one line per hit with the hit
+/// `id`, score, and the first line of content. Chronos prefers
+/// temporally-anchored single-line summaries.
+#[derive(Debug, Clone, Copy)]
+pub struct ChronosEnvelope;
+
+impl HarnessEnvelope for ChronosEnvelope {
+    fn shape(&self, hits: &[ScoredMemory]) -> String {
+        let mut out = String::new();
+        out.push_str("chronos recall envelope\n");
+        for m in hits {
+            let first_line = m.content.lines().next().unwrap_or("").trim();
+            out.push_str(&format!("t={:.3} id={} :: {}\n", m.score, m.id, first_line));
+        }
+        out
+    }
+}
+
+/// Generic envelope — minimal `id\tscore\tcontent` TSV one line per
+/// hit. The fallback when no harness-specific adapter applies.
+#[derive(Debug, Clone, Copy)]
+pub struct GenericEnvelope;
+
+impl HarnessEnvelope for GenericEnvelope {
+    fn shape(&self, hits: &[ScoredMemory]) -> String {
+        let mut out = String::new();
+        for m in hits {
+            // TSV-safe: replace tabs/newlines in content so the
+            // generic envelope stays parseable.
+            let content_safe = m.content.replace(['\t', '\n', '\r'], " ");
+            out.push_str(&format!("{}\t{:.3}\t{}\n", m.id, m.score, content_safe));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::memory::{MemoryType, Scope};
+    use uuid::Uuid;
+
+    fn make_hit(content: &str, score: f32) -> ScoredMemory {
+        ScoredMemory {
+            id: Uuid::now_v7(),
+            content: content.to_string(),
+            agent_id: "test-agent".to_string(),
+            memory_type: MemoryType::Episodic,
+            scope: Scope::Private,
+            importance: 0.5,
+            tags: vec![],
+            metadata: serde_json::Value::Null,
+            score,
+            access_count: 0,
+            created_at: "2026-05-17T00:00:00Z".to_string(),
+            updated_at: "2026-05-17T00:00:00Z".to_string(),
+            score_breakdown: None,
+        }
+    }
+
+    #[test]
+    fn retrieval_mode_round_trip_strategy_string() {
+        assert_eq!(RetrievalMode::VectorOnly.to_strategy_str(), "semantic");
+        assert_eq!(RetrievalMode::Bm25Only.to_strategy_str(), "lexical");
+        assert_eq!(RetrievalMode::HybridRrf.to_strategy_str(), "auto");
+        assert_eq!(RetrievalMode::Graph.to_strategy_str(), "graph");
+        let harness = RetrievalMode::HarnessAware {
+            harness: HarnessKind::ClaudeCode,
+            format: EnvelopeFormat::Inline,
+        };
+        // HarnessAware delegates to "auto" for the underlying
+        // retrieval — the adapter handles envelope post-processing.
+        assert_eq!(harness.to_strategy_str(), "auto");
+    }
+
+    #[test]
+    fn retrieval_mode_serde_round_trip() {
+        for mode in [
+            RetrievalMode::VectorOnly,
+            RetrievalMode::Bm25Only,
+            RetrievalMode::HybridRrf,
+            RetrievalMode::Graph,
+            RetrievalMode::HarnessAware {
+                harness: HarnessKind::ClaudeCode,
+                format: EnvelopeFormat::Inline,
+            },
+            RetrievalMode::HarnessAware {
+                harness: HarnessKind::Codex,
+                format: EnvelopeFormat::FileBased {
+                    path_root: PathBuf::from("/tmp/codex"),
+                },
+            },
+            RetrievalMode::HarnessAware {
+                harness: HarnessKind::Generic,
+                format: EnvelopeFormat::SideChannel,
+            },
+        ] {
+            let s = serde_json::to_string(&mode).unwrap();
+            let back: RetrievalMode = serde_json::from_str(&s).unwrap();
+            assert_eq!(mode, back, "round-trip failed for {mode:?} via {s}");
+        }
+    }
+
+    #[test]
+    fn harness_aware_returns_envelope_adapter() {
+        let mode = RetrievalMode::HarnessAware {
+            harness: HarnessKind::ClaudeCode,
+            format: EnvelopeFormat::Inline,
+        };
+        assert!(mode.envelope_adapter().is_some());
+        assert!(RetrievalMode::HybridRrf.envelope_adapter().is_none());
+    }
+
+    #[test]
+    fn five_adapters_produce_distinct_envelope_shapes() {
+        let hits = vec![
+            make_hit("first hit content line\nsecond line", 0.91),
+            make_hit("another hit", 0.42),
+        ];
+        let cc = ClaudeCodeEnvelope { inline: true }.shape(&hits);
+        let codex = CodexEnvelope { file_based: true }.shape(&hits);
+        let gemini = GeminiCliEnvelope.shape(&hits);
+        let chronos = ChronosEnvelope.shape(&hits);
+        let generic = GenericEnvelope.shape(&hits);
+        // Each adapter must produce a distinct shape — the whole
+        // point of HarnessAware is per-harness reshaping.
+        let shapes = [&cc, &codex, &gemini, &chronos, &generic];
+        for (i, a) in shapes.iter().enumerate() {
+            for (j, b) in shapes.iter().enumerate() {
+                if i != j {
+                    assert_ne!(
+                        a, b,
+                        "adapter shapes {} and {} collided (both produced:\n{a})",
+                        i, j
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn claude_code_envelope_inline_vs_non_inline_differ() {
+        let hits = vec![make_hit("hello world", 0.5)];
+        let inline = ClaudeCodeEnvelope { inline: true }.shape(&hits);
+        let non_inline = ClaudeCodeEnvelope { inline: false }.shape(&hits);
+        assert!(inline.contains("```"), "inline must contain fenced block");
+        assert!(
+            !non_inline.contains("```"),
+            "non-inline must not contain fenced block"
+        );
+    }
+
+    #[test]
+    fn generic_envelope_is_tsv_safe() {
+        let hits = vec![make_hit("has\ttab\nand newline", 0.5)];
+        let env = GenericEnvelope.shape(&hits);
+        // Exactly one record line — the inner \t and \n in content
+        // must have been replaced with spaces.
+        assert_eq!(env.lines().count(), 1);
+        let parts: Vec<&str> = env.trim_end().split('\t').collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "TSV envelope must have id\\tscore\\tcontent"
+        );
+    }
+}

--- a/crates/mnemo-core/tests/integration_test.rs
+++ b/crates/mnemo-core/tests/integration_test.rs
@@ -89,6 +89,7 @@ async fn test_full_lifecycle() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .expect("recall should succeed");
@@ -151,6 +152,7 @@ async fn test_full_lifecycle() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .expect("recall should succeed");
@@ -250,6 +252,7 @@ async fn test_multiple_memories_with_filtering() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -275,6 +278,7 @@ async fn test_multiple_memories_with_filtering() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -300,6 +304,7 @@ async fn test_multiple_memories_with_filtering() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -326,6 +331,7 @@ async fn test_multiple_memories_with_filtering() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -420,6 +426,7 @@ async fn test_access_count_increments() {
                 as_of: None,
                 explain: None,
                 with_provenance: None,
+                mode: None,
             })
             .await
             .unwrap();
@@ -865,6 +872,7 @@ async fn test_exact_recall_strategy() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -1102,6 +1110,7 @@ async fn test_quarantined_excluded_from_recall() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -1218,6 +1227,7 @@ async fn test_recall_scope_filter() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -1245,6 +1255,7 @@ async fn test_recall_scope_filter() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -1305,6 +1316,7 @@ async fn test_recall_multi_type_filter() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -1807,6 +1819,7 @@ async fn test_hybrid_with_graph_signal() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -1895,6 +1908,7 @@ async fn test_sync_push_pull() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -2100,6 +2114,7 @@ async fn test_permission_safe_ann() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -2210,6 +2225,7 @@ async fn test_as_of_point_in_time() {
             as_of: Some(t_between.clone()),
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -2237,6 +2253,7 @@ async fn test_as_of_point_in_time() {
             as_of: Some(t_after_both.clone()),
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -2266,6 +2283,7 @@ async fn test_as_of_point_in_time() {
             as_of: Some(t_after_delete.clone()),
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();
@@ -2319,6 +2337,7 @@ async fn test_event_integrity_verification() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();

--- a/crates/mnemo-core/tests/version_metadata.rs
+++ b/crates/mnemo-core/tests/version_metadata.rs
@@ -5,15 +5,16 @@
 //! inherits `version.workspace = true`, this transitively asserts that
 //! every published crate ships with the same version).
 //!
-//! This is the U1 regression test for v0.4.2 — see
+//! Originally landed as the U1 regression test for v0.4.2; bumped each
+//! cut alongside the workspace version. See
 //! [docs/compat/version-skew-matrix.md](../../docs/compat/version-skew-matrix.md).
 
 #[test]
-fn cargo_pkg_version_matches_v0_4_3() {
+fn cargo_pkg_version_matches_v0_4_4() {
     assert_eq!(
         env!("CARGO_PKG_VERSION"),
-        "0.4.3",
-        "mnemo-core CARGO_PKG_VERSION drifted from the v0.4.3 cut. \
+        "0.4.4",
+        "mnemo-core CARGO_PKG_VERSION drifted from the v0.4.4 cut. \
          Bump `workspace.package.version` in /Cargo.toml AND update \
          docs/compat/version-skew-matrix.md to match."
     );

--- a/crates/mnemo-grpc/src/lib.rs
+++ b/crates/mnemo-grpc/src/lib.rs
@@ -245,6 +245,7 @@ impl MnemoService for MnemoGrpcServer {
             as_of: req.as_of,
             explain: req.explain,
             with_provenance: None,
+            mode: None,
         };
 
         let result = self

--- a/crates/mnemo-letta/src/handlers.rs
+++ b/crates/mnemo-letta/src/handlers.rs
@@ -97,6 +97,7 @@ pub async fn send_message(
         as_of: None,
         explain: None,
         with_provenance: None,
+        mode: None,
     };
     let resp = engine
         .recall(recall)

--- a/crates/mnemo-mcp/tests/mcp_test.rs
+++ b/crates/mnemo-mcp/tests/mcp_test.rs
@@ -173,6 +173,7 @@ async fn test_engine_recall_via_server_engine() {
             as_of: None,
             explain: None,
             with_provenance: None,
+            mode: None,
         })
         .await
         .unwrap();

--- a/crates/mnemo-pgwire/src/server.rs
+++ b/crates/mnemo-pgwire/src/server.rs
@@ -188,6 +188,7 @@ async fn handle_query(
                 as_of: None,
                 explain: None,
                 with_provenance: None,
+                mode: None,
             };
 
             let response = engine.recall(request).await?;

--- a/crates/mnemo-rest/src/handlers.rs
+++ b/crates/mnemo-rest/src/handlers.rs
@@ -211,6 +211,7 @@ pub async fn recall_handler(
         as_of: params.as_of,
         explain: params.explain,
         with_provenance: None,
+        mode: None,
     };
 
     let response = engine.recall(request).await?;

--- a/docs/compat/version-skew-matrix.md
+++ b/docs/compat/version-skew-matrix.md
@@ -1,6 +1,6 @@
 # Mnemo Version Skew Matrix
 
-> Updated 2026-05-04 for the v0.4.3 cut.
+> Updated 2026-05-17 for the v0.4.4 cut.
 
 The matrix below pins which downstream and upstream versions are tested
 together for each `mnemo` workspace release. Bumping any cell requires a
@@ -11,15 +11,33 @@ source-of-truth — see [CHANGELOG](../../CHANGELOG.md)).
 
 | `mnemo` (Cargo workspace) | `rmcp` | `tantivy` | `usearch` | `duckdb` | `pgvector` | `sqlx` | Cloudflare substrate ³ |
 |---|---|---|---|---|---|---|---|
-| **0.4.3** (planned) | 1.3 | 0.26 | 2.21 | **1.10502.0** ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize **+** DO Facets SQLite ³ |
+| **0.4.4** (2026-05-17) | 1.3 | 0.26 | 2.21 | 1.10502.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
+| 0.4.3 (2026-05-04) | 1.3 | 0.26 | 2.21 | 1.10502.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.4.2 (2026-05-03) | 1.3 | 0.26 | 2.21 | 1.4 | 0.8.2 | 0.8 | Workers KV+Vectorize (anchor only) |
 
 ## SDK side (Python / TypeScript / Go + MCP SDKs)
 
 | `mnemo` | Python SDK (`mnemo-db`) | TS SDK (`@mndfreek/mnemo-sdk`) | Go SDK (`mnemo.Version`) | `mcp-python` ⁵ | `mcp-go` ⁵ | `mcp-ruby` ⁵ | `mcp-csharp` ⁵ |
 |---|---|---|---|---|---|---|---|
-| **0.4.3** (planned) | 0.4.3 | 0.4.3 | 0.4.3 | 1.13.x (2026-05-01) | 0.31.x (2026-05-01) | 0.5.x (2026-05-02) | 0.4.x (2026-05-02) |
+| **0.4.4** (2026-05-17) | 0.4.4 | 0.4.4 | 0.4.4 | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
+| 0.4.3 (2026-05-04) | 0.4.3 | 0.4.3 | 0.4.3 | 1.13.x (2026-05-01) | 0.31.x (2026-05-01) | 0.5.x (2026-05-02) | 0.4.x (2026-05-02) |
 | 0.4.2 (2026-05-03) | 0.4.2 | 0.4.2 | 0.4.2 | 1.12.x | 0.30.x | 0.4.x | 0.3.x |
+
+## v0.4.4 retrieval surface (new in this release)
+
+| Feature | Where it lives | API shape |
+|---|---|---|
+| `RetrievalMode` typed enum | [`crates/mnemo-core/src/retrieval.rs`](../../crates/mnemo-core/src/retrieval.rs) | 5 variants: `VectorOnly` / `Bm25Only` / `HybridRrf` / `Graph` / `HarnessAware { harness, format }` |
+| Backwards-compat dispatch | [`crates/mnemo-core/src/query/recall.rs`](../../crates/mnemo-core/src/query/recall.rs) — `execute()` prefers `mode` over legacy `strategy` string | `RecallRequest.mode: Option<RetrievalMode>` (additive); `RecallRequest.strategy: Option<String>` unchanged |
+| 5 starter `HarnessAware` adapters | `retrieval.rs` — `ClaudeCodeEnvelope`, `CodexEnvelope`, `GeminiCliEnvelope`, `ChronosEnvelope`, `GenericEnvelope` | `trait HarnessEnvelope { fn shape(&self, hits: &[ScoredMemory]) -> String; }` |
+| Research anchor | [`docs/research/grep-vs-vector-2605.15184.md`](../research/grep-vs-vector-2605.15184.md) | Composition anchor, not implementation claim |
+| Bench scaffold | [`bench/locomo/src/bin/grep_vs_vector_replay.rs`](../../bench/locomo/src/bin/grep_vs_vector_replay.rs) | Routes LongMemEval-shaped slice through 3 modes; smoke metric only (gated full run = #44) |
+
+**SDK callers are NOT affected by v0.4.4.** The Python / TypeScript /
+Go SDKs continue to marshal `strategy: string` and continue to work
+unchanged — the new `mode` field is purely additive on
+`RecallRequest`. SDK migration to a typed `mode` field is a v0.5.x
+follow-up.
 
 ## History
 

--- a/docs/research/grep-vs-vector-2605.15184.md
+++ b/docs/research/grep-vs-vector-2605.15184.md
@@ -1,0 +1,110 @@
+# Grep vs vector retrieval inside agent harnesses — arXiv 2605.15184 anchor
+
+> Recorded 2026-05-17. **Composition anchor, not a marketing claim.**
+> Sen et al.'s paper is an external research artifact; mnemo's relevance
+> is structural — hybrid RRF over BM25 + vector + graph + recency is
+> already the documented default. This note records the framing the
+> paper provides for mnemo's existing surfaces and the new
+> v0.4.4 `RetrievalMode::HarnessAware` lever, without claiming any
+> result the paper does not.
+
+## Citation
+
+- **Paper:** Sen et al. (PwC), "Is Grep All You Need?" (paraphrased
+  title used in prose; literal title in §Sources).
+- **arXiv:** [2605.15184](https://arxiv.org/abs/2605.15184)
+- **Released:** May 2026
+
+## What the paper measures
+
+Two findings from the abstract drive today's anchor:
+
+1. **"grep generally yields higher accuracy than vector retrieval in
+   our comparisons in experiment 1"** — Across a controlled agent
+   harness, exact-keyword BM25-style retrieval outperformed pure
+   embedding-vector retrieval on the experiment-1 corpus.
+2. **"overall scores still depend strongly on which harness and
+   tool-calling style is used, even when the underlying conversation
+   data are the same"** — The result envelope shape (how the
+   retrieved hits are framed for the agent) is a measured lever
+   independent of the substrate's retrieval strategy.
+
+The paper's contribution is the *measurement*: a reproducible
+experimental design that isolates retrieval mode from envelope
+format. It does not propose a new substrate; it asks whether the
+mainstream "vector-first" default is the right one.
+
+## Where mnemo fits
+
+mnemo's documented default retrieval path is **already hybrid RRF
+over BM25 + vector + graph + recency**, with operator-configurable
+weights via `RecallRequest.hybrid_weights`. The paper's BM25-favours
+finding is the substrate's *expected* shape — mnemo did not need a
+pivot to accommodate it; the substrate was already hedged.
+
+What v0.4.4 adds for the second finding (envelope-format lever) is a
+typed `RetrievalMode::HarnessAware { harness, format }` variant that
+selects a per-harness envelope adapter (Claude Code / Codex /
+Gemini CLI / Chronos / Generic) without changing which records the
+substrate retrieves. The five adapters are intentionally minimal —
+each produces a deterministic string shape; envelope-content
+stability is not claimed in v0.4.4.
+
+| Paper's lever | mnemo surface |
+|---|---|
+| Compare BM25 vs vector vs hybrid on the same data | `bench/locomo/src/bin/grep_vs_vector_replay.rs` (landed alongside this anchor in PR-A) routes a LongMemEval-shaped slice through `mnemo.recall` in all three modes and emits a Markdown table |
+| Hold retrieval constant, vary envelope per harness | `RetrievalMode::HarnessAware { harness, format }` (new in v0.4.4) — the substrate retrieves via `HybridRrf`, an adapter reshapes the response per harness |
+| Reproducible-experiment harness | The replay bin's smoke run is bundled-dataset-only; the gated 116-question LongMemEval slice + GPT-judge-scored metric require the same secrets as [#44](https://github.com/sattyamjjain/mnemo/issues/44) |
+
+## What this anchor is NOT
+
+- **Not an endorsement of grep-default.** mnemo's default stays
+  hybrid RRF. The paper's first finding sharpens *why* the hybrid
+  path is the right default (BM25 contributes more than a
+  vector-first reading would suggest), not why mnemo should pivot
+  to grep-default.
+- **Not a benchmark-result claim.** The bundled smoke run in the
+  replay bin uses `NoopEmbedding` (zero vectors) so the vector-only
+  column is degenerate by design. Real numbers comparable to the
+  paper need the gated run.
+- **Not an integration with the paper's harness.** The paper does not
+  ship an API or a public test corpus mnemo can bind against.
+- **Not a stability claim on envelope contents.** The five
+  `HarnessAware` adapters produce deterministic shapes per harness
+  but the exact byte-level content is not a stability surface in
+  v0.4.4. Operators pinning a specific envelope format should pin
+  the mnemo minor version.
+
+## Why a `RetrievalMode` typed enum at all
+
+Before v0.4.4, `RecallRequest.strategy: Option<String>` was the only
+recall-mode lever — string-typed, with magic values `"semantic"`,
+`"lexical"`, `"auto"`, `"graph"`. The paper's second finding
+(envelope-format matters independently of retrieval) is awkward to
+express as a string variant — `HarnessAware` carries two fields
+(`harness`, `format`) that don't compose into a flat string.
+
+v0.4.4 introduces `RetrievalMode` as a typed superset alongside the
+legacy string field. `RecallRequest.mode: Option<RetrievalMode>` is
+additive — when set it takes precedence; when unset the engine
+falls back to parsing `strategy` exactly as in v0.4.3. **No SDK
+breaking change** — the Python / TypeScript / Go SDKs continue to
+marshal `strategy: string` and continue to work.
+
+A future v0.5.x can migrate the SDKs to a typed `mode` field; that
+breaking change is out of scope for v0.4.4.
+
+## Cross-references
+
+- Bench scaffold: [`../../bench/locomo/src/bin/grep_vs_vector_replay.rs`](../../bench/locomo/src/bin/grep_vs_vector_replay.rs) — runnable today against the bundled `longmemeval_m.jsonl`.
+- RetrievalMode enum + 5 adapters: [`../../crates/mnemo-core/src/retrieval.rs`](../../crates/mnemo-core/src/retrieval.rs).
+- Companion read-side composition anchor: [`argus-2605.03378.md`](argus-2605.03378.md) (ARGUS — 2026-05-05, same composition-anchor pattern).
+- Companion outcome-diffing anchor: [`delegate52-2604.15597.md`](delegate52-2604.15597.md) (DELEGATE-52 — 2026-05-09).
+- Companion curator anchor: [`../comparisons/anthropic-dreams.md`](../comparisons/anthropic-dreams.md) (Dreams — 2026-05-06).
+- v0.4.4 carry list: [`../../CHANGELOG.md`](../../CHANGELOG.md) `[0.4.4]` section.
+- Gated full-run blocker: [#44](https://github.com/sattyamjjain/mnemo/issues/44).
+
+## Sources
+
+- arXiv 2605.15184 — https://arxiv.org/abs/2605.15184 — *"Is Grep All You Need?"* (Sen et al., PwC, May 2026; literal title used here per the §Sources-only paraphrase rule).
+- Hacker News front-page surface (per 2026-05-17 daily-prompt digest).

--- a/python/mnemo/__init__.py
+++ b/python/mnemo/__init__.py
@@ -12,7 +12,7 @@ Example::
     memories = client.recall("user preferences")
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __all__: list[str] = []
 
 # The native PyO3 extension is optional at import time — users who only need

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 # the PyPI distribution name moves. Users do `pip install mnemo-db`
 # then `from mnemo import MnemoClient`.
 name = "mnemo-db"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP-native memory database for AI agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/tests/test_version_alignment.py
+++ b/python/tests/test_version_alignment.py
@@ -61,6 +61,6 @@ def test_python_sdk_version_matches_pyproject() -> None:
     )
 
 
-def test_v0_4_3_pinned() -> None:
+def test_v0_4_4_pinned() -> None:
     """Sanity-check this exact release. Bump alongside CHANGELOG."""
-    assert mnemo.__version__ == "0.4.3"
+    assert mnemo.__version__ == "0.4.4"

--- a/sdks/go/mnemo.go
+++ b/sdks/go/mnemo.go
@@ -1,7 +1,7 @@
 // Package mnemo is the Go SDK for Mnemo — MCP-native memory database for
 // AI agents.
 //
-// Package version: 0.4.3
+// Package version: 0.4.4
 package mnemo
 
 import (
@@ -15,7 +15,7 @@ import (
 
 // Version is the SDK version. Kept in lockstep with the Cargo workspace
 // `workspace.package.version` and `python/pyproject.toml` `version`.
-const Version = "0.4.3"
+const Version = "0.4.4"
 
 // ClientOptions configures the Mnemo MCP client.
 type ClientOptions struct {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mndfreek/mnemo-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "TypeScript SDK for Mnemo — MCP-native memory database for AI agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

**PR B of two** for today's 2026-05-17 daily prompt. Suggestion 2 from the product-improvements digest. **Workspace bumped 0.4.3 → 0.4.4**; PR A (bench scaffold) landed under v0.4.3 at commit `cde9f68`. This PR is the v0.4.4 cut — the merge triggers the full 17-crate cargo-publish chain.

**The `!` in the conventional subject tracks the workspace version flip + the new public surface**, NOT an SDK-breaking change. The addition is purely additive:

- `RecallRequest.strategy: Option<String>` stays in place
- `RecallRequest.mode: Option<RetrievalMode>` is new and additive
- When `mode` is set it takes precedence; otherwise the engine dispatches via the legacy `strategy` string exactly as in v0.4.3
- Python / TypeScript / Go SDKs continue to marshal `strategy: string` and continue to work unchanged

### What lands

**New `mnemo_core::retrieval` module** (`crates/mnemo-core/src/retrieval.rs`):

- `pub enum RetrievalMode { VectorOnly, Bm25Only, HybridRrf, Graph, HarnessAware { harness, format } }`
- `pub enum HarnessKind { ClaudeCode, Codex, GeminiCli, Chronos, Generic }`
- `pub enum EnvelopeFormat { Inline, FileBased { path_root }, SideChannel }`
- `pub trait HarnessEnvelope { fn shape(&self, hits: &[ScoredMemory]) -> String; }`
- **5 starter adapters**: `ClaudeCodeEnvelope` (fenced markdown), `CodexEnvelope` (JSON pointers), `GeminiCliEnvelope` (numbered list), `ChronosEnvelope` (timeline single-line), `GenericEnvelope` (TSV-safe)
- 6 unit tests: strategy_str round-trip, serde round-trip (incl. struct variant), harness_adapter optional, 5 adapters produce distinct shapes, Claude Code inline-vs-non, Generic TSV-safety

**Dispatch wiring** (`crates/mnemo-core/src/query/recall.rs`):

- New `mode: Option<RetrievalMode>` field on `RecallRequest` (`#[serde(default, skip_serializing_if = "Option::is_none")]` — inbound JSON from v0.4.3 SDKs deserializes unchanged)
- `execute()` checks `request.mode` first; falls back to legacy `strategy` string
- 20+ workspace `RecallRequest` construction sites updated to set `mode: None`

**Workspace cut**:

- `Cargo.toml workspace.package.version`: 0.4.3 → 0.4.4 + all internal `mnemo-*` dep pins
- Python `mnemo-db@0.4.4` + TypeScript `@mndfreek/mnemo-sdk@0.4.4` + Go `mnemo.Version`/doc-comment 0.4.4
- Version regression tests bumped + renamed (`cargo_pkg_version_matches_v0_4_4`, `test_v0_4_4_pinned`)
- `docs/compat/version-skew-matrix.md` gains the v0.4.4 row + a new "v0.4.4 retrieval surface" section

**Documentation**:

- New [`docs/research/grep-vs-vector-2605.15184.md`](docs/research/grep-vs-vector-2605.15184.md) composition anchor mirroring the ARGUS / DELEGATE-52 / Dreams pattern. Explicit non-overclaim disclaimers throughout
- README "Why mnemo when Cloudflare Agent Memory exists?" gains a paragraph framing the HarnessAware lever against the paper's envelope-format finding
- CHANGELOG `[Unreleased]` → `[0.4.4] - 2026-05-17`; fresh `[Unreleased]` opened above with a `### Landing trace (2026-05-17)` sub-block referencing PR A's commit SHA (satisfies the `changelog_has_landing_trace_section` regression test)
- README marketing-phrase banlist extended with 4 grep-vs-vector overclaim phrasings: `grep killer`, `vector retrieval is dead`, `RAG killer`, `harness-perfect`

### Honest scope — what's NOT in this release

- **NOT an SDK breaking change.** SDKs continue to use `strategy: string` unchanged
- **NOT a REST / gRPC / pgwire schema bump.** Inbound requests omitting `mode` dispatch via legacy `strategy`
- **NOT an envelope-content stability surface.** The 5 HarnessAware adapter shapes are starters; pin v0.4.4 minor if relying on byte-level output
- **NOT a GPT-judge-scored bench result.** The PR-A `grep_vs_vector_replay` bin emits a deterministic smoke metric; official LongMemEval scoring stays gated behind [#44](https://github.com/sattyamjjain/mnemo/issues/44)
- **NOT a `mnemo-bench-cf` / `mnemo-langgraph` / `mnemo-purview` / `mnemo-envelope` crate land** — parked v0.4.4-backlog inventory in CHANGELOG stays untouched

### Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --workspace --exclude mnemo-python -- -D warnings` clean
- [x] `cargo test --workspace --exclude mnemo-python --no-fail-fast` — **367 passed**, 0 failed, 5 ignored (+6 from new `retrieval::tests` vs v0.4.3 baseline)
- [x] All 15 README + CHANGELOG structural tests still pass at v0.4.4
- [x] `cargo_pkg_version_matches_v0_4_4` ✓

### Sequencing + publish

PR A merged at `cde9f68` (workspace=0.4.3; bench/locomo `publish = false` so cargo-publish precheck no-opped). This PR is the v0.4.4 cut — the merge triggers the full 17-crate cargo-publish chain at the bumped 300-min job timeout (from PR #75). Should complete one-shot in ~250 min as in the v0.4.3 cut.

### Sources

- arXiv:2605.15184 (Sen et al. PwC — "Is Grep All You Need?") — primary evidence anchor for both suggestions
- PR A commit `cde9f68` referenced in `[Unreleased]` Landing trace sub-block
- v0.4.4 backlog: 7 parked crates in [CHANGELOG.md](CHANGELOG.md) `Parked for v0.4.4 backlog` section — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)