### PR TITLE
feat(langgraph): MnemoCheckpointer canonical name + LangGraph 1.x adapter wrap-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,47 @@ All notable changes to Mnemo are documented in this file.
 
 ## [Unreleased]
 
-### Landing trace (2026-05-17)
+### Landing trace (2026-05-18)
 
-v0.4.4 cut today. Next cycle's accumulator opens here. PR-A of the
-v0.4.4 cut (bench scaffold) landed in commit
+v0.4.4 cut shipped 2026-05-17; this `[Unreleased]` accumulator opens
+the v0.4.5 cycle. PR-A of v0.4.4 landed in commit
 [`cde9f68`](https://github.com/sattyamjjain/mnemo/commit/cde9f68f859856192243c5cec037d65b382b5085);
-PR-B of the v0.4.4 cut (RetrievalMode typed enum + 5 HarnessAware
-adapters + arXiv:2605.15184 research-anchor doc + workspace bump)
-follows in this branch.
+PR-B (RetrievalMode typed enum + 5 HarnessAware adapters +
+arXiv:2605.15184 anchor + workspace bump) merged 2026-05-18 in
+commit [`2a7b619`](https://github.com/sattyamjjain/mnemo/commit/2a7b6199a650af90c0922ef4bd4af64a98872e7f).
+
+### Added
+
+- **(2026-05-18) — LangGraph 1.x checkpoint adapter wrap-up.**
+  `python/mnemo/checkpointer.py` adds **`MnemoCheckpointer`** as the
+  canonical class name; the legacy `ASMDCheckpointer` is preserved
+  as a back-compat alias so existing `from mnemo.checkpointer
+  import ASMDCheckpointer` imports continue to work. The module
+  docstring now documents the LangGraph 1.x ``BaseCheckpointSaver``
+  surface coverage explicitly: primaries (`get_tuple`, `put`,
+  `delete_thread`) are implemented; `list` + `put_writes` are stubs
+  with the contract recorded in the docstring. New tests in
+  [`python/tests/test_langgraph_checkpointer.py`](python/tests/test_langgraph_checkpointer.py)
+  cover put→get_tuple round-trip, thread isolation, branch round-trip,
+  delete_thread, stub-method contracts, and the back-compat-alias
+  identity (`ASMDCheckpointer is MnemoCheckpointer`). Tests use a
+  `_FakeMnemoClient` shim so the suite does NOT spawn the mnemo
+  binary. New
+  [`examples/langgraph_checkpointer.py`](examples/langgraph_checkpointer.py)
+  shows a 5-line `StateGraph` + `MnemoCheckpointer` integration.
+  [`python/README.md`](python/README.md) integrations table swaps
+  `ASMDCheckpointer` → `MnemoCheckpointer` with the back-compat
+  alias annotated inline. `mnemo.availability` registers both names
+  so the soft-import probe surfaces either.
+
+  **Honest scope:** this wrap-up closes the parked
+  `mnemo-langgraph` v0.4.4-backlog item via the existing Python
+  adapter; **no new Rust crate ships** because LangGraph is
+  Python-only and a Rust `crates/mnemo-langgraph/` shell would have
+  no downstream consumer. The Python adapter's `list` +
+  `put_writes` stubs are unchanged — the v0.4.4-backlog inventory
+  is moved from "ship the crate" to "implement `list` + per-thread
+  `put_writes` enumeration" as a v0.5.x follow-up.
 
 ## [0.4.4] - 2026-05-17
 
@@ -99,9 +132,14 @@ parsing 17 days of prompt history.
   service and (b) the DO Facets SQLite-per-DO substrate. Strongest
   v0.4.4 headline candidate. Empty-bench placeholders are tracked
   in [`docs/comparisons/cloudflare-agent-memory.md`](docs/comparisons/cloudflare-agent-memory.md).
-- **`mnemo-langgraph`** (S/M) — LangGraph 1.x checkpoint adapter.
-  Waiting on a fresh ≤7d `langgraph-checkpoint` release; the
-  2026-04-27 release is just past the gate.
+- **`mnemo-langgraph` Rust crate — RETIRED 2026-05-18.** The parked
+  item was a Rust shell that would have had no downstream consumer.
+  The functionally-equivalent Python adapter (now canonical name
+  `MnemoCheckpointer`, back-compat alias `ASMDCheckpointer`) covers
+  LangGraph 1.x's `BaseCheckpointSaver` interface in `python/mnemo/checkpointer.py`.
+  Remaining work (implement the stub `list` + `put_writes` methods)
+  is rebased to a v0.5.x follow-up — see today's `[Unreleased]`
+  Added entry above.
 - **`mnemo-purview`** (M-effort) — Microsoft Purview audit-log
   adapter. No S-shippable subset surfaced yet.
 - **`mnemo-toolhive`** (S) — Stacklok ToolHive Registry sync.

--- a/examples/langgraph_checkpointer.py
+++ b/examples/langgraph_checkpointer.py
@@ -1,0 +1,63 @@
+"""Five-line LangGraph 1.x checkpoint integration with Mnemo.
+
+Pairs LangGraph's `StateGraph` with `MnemoCheckpointer` so every
+state transition lands in Mnemo's checkpoint / branch / merge store
+with the HMAC envelope chain + offline-replayable provenance the
+rest of the mnemo surface already provides.
+
+Run after `pip install mnemo-db[langgraph]` (matches the optional
+extra registered in `python/pyproject.toml`).
+
+The full LangGraph 1.x ``BaseCheckpointSaver`` coverage is documented
+inside `mnemo/checkpointer.py` — primaries (`put` / `get_tuple` /
+`delete_thread`) are real; `list` + `put_writes` are stubs today.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+# LangGraph 1.x — minimal smoke example. Replace the toy node with
+# your real agent step in production.
+from langgraph.graph import END, START, StateGraph  # type: ignore[import-not-found]
+
+from mnemo.checkpointer import MnemoCheckpointer
+
+
+class State(TypedDict):
+    counter: int
+
+
+def increment(state: State) -> State:
+    return {"counter": state["counter"] + 1}
+
+
+def main() -> None:
+    # 1. Build a LangGraph state graph.
+    graph = StateGraph(State)
+    graph.add_node("increment", increment)
+    graph.add_edge(START, "increment")
+    graph.add_edge("increment", END)
+
+    # 2. Compile with `MnemoCheckpointer` — every node transition
+    #    persists a checkpoint into the local `agent.mnemo.db`.
+    checkpointer = MnemoCheckpointer(db_path="agent.mnemo.db", agent_id="example-agent")
+    app = graph.compile(checkpointer=checkpointer)
+
+    # 3. Invoke; the `thread_id` in `configurable` scopes the
+    #    checkpoint stream and lets future runs resume / replay.
+    config = {"configurable": {"thread_id": "session-1", "branch": "main"}}
+    final = app.invoke({"counter": 0}, config=config)
+    print(f"final state: {final}")
+
+    # 4. Each LangGraph thread maps to a mnemo `thread_id`; recall
+    #    the latest checkpoint via the typed Mnemo API to verify
+    #    the bridge wrote what the agent saw.
+    tup = checkpointer.get_tuple(config)
+    if tup is not None:
+        print(f"latest checkpoint id: {tup.checkpoint['id']}")
+        print(f"branch: {tup.metadata['branch']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/README.md
+++ b/python/README.md
@@ -36,7 +36,7 @@ client.forget([result["id"]])
 | `MnemoMemoryToolServer` | Anthropic `memory_20250818` 6-op handler. `pip install 'mnemo-db[anthropic-memory-tool]'` |
 | `MnemoLettaShared` | Letta-style Conversations adapter for shared agent memory |
 | `S3Workspace` / `CloudflareR2Workspace` | OpenAI Agents SDK GA snapshot store backends. `pip install 'mnemo-db[openai-sandbox-s3]'` or `[openai-sandbox-r2]` |
-| `MnemoAgentMemory` (OpenAI), `Mem0Compat`, `ASMDCheckpointer` (LangGraph), 12 more | Drop-in framework integrations. Install the matching extra. |
+| `MnemoAgentMemory` (OpenAI), `Mem0Compat`, `MnemoCheckpointer` (LangGraph 1.x — `ASMDCheckpointer` is the back-compat alias), 12 more | Drop-in framework integrations. Install the matching extra. |
 
 ## Optional extras
 

--- a/python/mnemo/__init__.py
+++ b/python/mnemo/__init__.py
@@ -33,9 +33,9 @@ __all__.append("MnemoMCPConfig")
 
 # Optional framework integrations (fail gracefully if deps not installed)
 try:
-    from mnemo.checkpointer import ASMDCheckpointer
+    from mnemo.checkpointer import ASMDCheckpointer, MnemoCheckpointer
 
-    __all__.append("ASMDCheckpointer")
+    __all__.extend(["ASMDCheckpointer", "MnemoCheckpointer"])
 except ImportError:
     pass
 

--- a/python/mnemo/availability.py
+++ b/python/mnemo/availability.py
@@ -82,6 +82,7 @@ def native_build_hint() -> str:
 # lazy try-except lattice.
 _ADAPTER_MODULES: tuple[tuple[str, str], ...] = (
     ("MnemoClient", "mnemo._mnemo"),
+    ("MnemoCheckpointer", "mnemo.checkpointer"),
     ("ASMDCheckpointer", "mnemo.checkpointer"),
     ("MnemoAgentMemory", "mnemo.openai_agents"),
     ("Mem0Compat", "mnemo.mem0_compat"),

--- a/python/mnemo/checkpointer.py
+++ b/python/mnemo/checkpointer.py
@@ -1,16 +1,38 @@
 """LangGraph checkpoint integration for Mnemo.
 
-Provides ASMDCheckpointer that implements LangGraph's BaseCheckpointSaver
-interface, backed by Mnemo's checkpoint/branch/merge system.
+Provides `MnemoCheckpointer` (canonical name as of v0.4.5) and its
+back-compat alias `ASMDCheckpointer`, both implementing LangGraph's
+`BaseCheckpointSaver` interface (1.x API surface — `get_tuple` /
+`put` / `list` / `put_writes` / `delete_thread`), backed by Mnemo's
+checkpoint / branch / merge system.
+
+`MnemoCheckpointer` is the documented name in v0.4.5+. `ASMDCheckpointer`
+remains exported as an alias so existing imports continue to work
+unchanged. Pick the new name in new code.
 
 Usage::
 
     from mnemo import MnemoClient
-    from mnemo.checkpointer import ASMDCheckpointer
+    from mnemo.checkpointer import MnemoCheckpointer
 
-    checkpointer = ASMDCheckpointer(db_path="agent.mnemo.db")
-    # Use with LangGraph:
+    checkpointer = MnemoCheckpointer(db_path="agent.mnemo.db")
+    # Use with LangGraph 1.x:
     # graph = create_graph().compile(checkpointer=checkpointer)
+
+LangGraph 1.x interface coverage:
+
+- ``get_tuple(config)``    — implemented; returns a CheckpointTuple
+                              for the (thread_id, checkpoint_id, branch)
+                              addressed by ``config``.
+- ``put(config, …)``        — implemented; persists a checkpoint into
+                              Mnemo's branch-aware checkpoint store.
+- ``put_writes(config, …)`` — stub no-op; intermediate writes are not
+                              independently persisted today.
+- ``list(config, …)``       — stub empty iterator; enumerating
+                              checkpoints across threads is not yet
+                              wired through ``MnemoClient``.
+- ``delete_thread(config)`` — implemented via ``forget`` over the
+                              thread's memory records.
 """
 
 from __future__ import annotations
@@ -28,12 +50,19 @@ from langgraph.checkpoint.base import (
 from mnemo import MnemoClient
 
 
-class ASMDCheckpointer(BaseCheckpointSaver):
+class MnemoCheckpointer(BaseCheckpointSaver):
     """LangGraph-compatible checkpoint saver backed by Mnemo.
 
-    This bridges LangGraph's checkpoint interface with Mnemo's
-    checkpoint/branch/merge system, providing persistent state
-    management with git-like branching.
+    Bridges LangGraph's 1.x ``BaseCheckpointSaver`` interface to
+    Mnemo's checkpoint / branch / merge system, giving operators
+    persistent agent state with git-like branching, a verifiable
+    HMAC audit chain on every write, and offline-replayable
+    point-in-time recall.
+
+    Canonical name as of v0.4.5. The earlier name
+    :class:`ASMDCheckpointer` is preserved as an alias for
+    back-compatibility — see the alias defined at the bottom of this
+    module.
     """
 
     def __init__(
@@ -132,3 +161,13 @@ class ASMDCheckpointer(BaseCheckpointSaver):
             self.client.forget([thread_id])
         except Exception:
             pass
+
+
+# v0.4.5 — back-compat alias for the legacy class name. Existing imports
+# (``from mnemo.checkpointer import ASMDCheckpointer``) continue to work
+# unchanged. The canonical name is :class:`MnemoCheckpointer`; pick that
+# in new code.
+ASMDCheckpointer = MnemoCheckpointer
+
+
+__all__ = ["MnemoCheckpointer", "ASMDCheckpointer"]

--- a/python/tests/test_langgraph_checkpointer.py
+++ b/python/tests/test_langgraph_checkpointer.py
@@ -1,0 +1,210 @@
+"""v0.4.5 — tests for `MnemoCheckpointer` (LangGraph 1.x adapter).
+
+Coverage:
+- put → get_tuple round-trip for a single thread.
+- Thread isolation: two threads, separate state.
+- Branch round-trip: `branch="dev"` flows through `config.configurable`.
+- delete_thread: invokes `MnemoClient.forget` with the thread id.
+- Stub methods: `list` yields nothing; `put_writes` is a no-op.
+- Back-compat: `ASMDCheckpointer` is the same class as `MnemoCheckpointer`.
+
+The tests stub `MnemoClient` so the suite does NOT spawn the mnemo
+binary; the unit being exercised is the LangGraph-shape ↔ Mnemo-API
+translation, not the underlying engine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+# Skip the whole module when LangGraph isn't installed, matching the
+# soft-import pattern in `mnemo.__init__`.
+pytest.importorskip("langgraph.checkpoint.base")
+
+from mnemo import checkpointer as ckpt_module  # noqa: E402
+from mnemo.checkpointer import ASMDCheckpointer, MnemoCheckpointer  # noqa: E402
+
+
+@dataclass
+class _FakeMnemoClient:
+    """In-process MnemoClient stand-in.
+
+    Implements only the surface `MnemoCheckpointer` actually calls:
+    ``checkpoint`` / ``replay`` / ``forget``. Each call is recorded so
+    tests can assert the LangGraph-shape ↔ Mnemo-API translation.
+    """
+
+    checkpoints: dict[tuple[str, str, str], dict[str, Any]] = field(default_factory=dict)
+    """(thread_id, branch, checkpoint_id) → stored state."""
+    last_checkpoint_per_branch: dict[tuple[str, str], str] = field(default_factory=dict)
+    """(thread_id, branch) → most recent checkpoint_id, used when caller
+    omits `checkpoint_id` from `get_tuple`."""
+    forgets: list[list[str]] = field(default_factory=list)
+
+    def checkpoint(
+        self,
+        thread_id: str,
+        state_snapshot: dict[str, Any],
+        branch_name: str = "main",
+        label: str | None = None,
+    ) -> dict[str, Any]:
+        cid = f"ckpt-{len(self.checkpoints) + 1}"
+        self.checkpoints[(thread_id, branch_name, cid)] = {
+            "id": cid,
+            "thread_id": thread_id,
+            "branch_name": branch_name,
+            "label": label,
+            "state": state_snapshot,
+            "created_at": "2026-05-18T00:00:00Z",
+        }
+        self.last_checkpoint_per_branch[(thread_id, branch_name)] = cid
+        return {"checkpoint_id": cid}
+
+    def replay(
+        self,
+        thread_id: str,
+        checkpoint_id: str | None = None,
+        branch_name: str = "main",
+    ) -> dict[str, Any]:
+        if checkpoint_id is None:
+            checkpoint_id = self.last_checkpoint_per_branch.get((thread_id, branch_name))
+            if checkpoint_id is None:
+                raise KeyError(f"no checkpoint for thread={thread_id} branch={branch_name}")
+        key = (thread_id, branch_name, checkpoint_id)
+        if key not in self.checkpoints:
+            raise KeyError(f"checkpoint missing: {key!r}")
+        cp = self.checkpoints[key]
+        return {"checkpoint": cp}
+
+    def forget(self, ids: list[str]) -> dict[str, Any]:
+        self.forgets.append(list(ids))
+        return {"forgotten": list(ids), "errors": []}
+
+
+def _build_checkpointer(monkeypatch: pytest.MonkeyPatch) -> tuple[MnemoCheckpointer, _FakeMnemoClient]:
+    """Construct a `MnemoCheckpointer` whose `client` is a `_FakeMnemoClient`."""
+    fake = _FakeMnemoClient()
+    # Patch the symbol the checkpointer module resolved at import time
+    # so `MnemoCheckpointer.__init__` picks up the fake.
+    monkeypatch.setattr(ckpt_module, "MnemoClient", lambda **kwargs: fake)
+    return MnemoCheckpointer(db_path=":memory:", agent_id="test-agent"), fake
+
+
+def _config(thread_id: str, branch: str = "main", checkpoint_id: str | None = None) -> dict:
+    cfg: dict[str, Any] = {"configurable": {"thread_id": thread_id, "branch": branch}}
+    if checkpoint_id is not None:
+        cfg["configurable"]["checkpoint_id"] = checkpoint_id
+    return cfg
+
+
+def _checkpoint(value: int) -> dict[str, Any]:
+    return {
+        "v": 1,
+        "id": "n/a",
+        "ts": "",
+        "channel_values": {"counter": value},
+        "channel_versions": {"counter": 1},
+        "versions_seen": {},
+    }
+
+
+def test_put_then_get_tuple_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, fake = _build_checkpointer(monkeypatch)
+
+    out = cp.put(_config("t1"), _checkpoint(7), {"step_type": "agent"}, {})
+
+    assert out["configurable"]["thread_id"] == "t1"
+    assert out["configurable"]["checkpoint_id"].startswith("ckpt-")
+    assert len(fake.checkpoints) == 1
+    cid = out["configurable"]["checkpoint_id"]
+    stored = fake.checkpoints[("t1", "main", cid)]
+    assert stored["state"]["channel_values"] == {"counter": 7}
+    assert stored["label"] == "agent"
+
+    # Now resolve via get_tuple using only the thread id (no
+    # checkpoint_id in config) — the fake should fall back to the
+    # most recent checkpoint for the branch.
+    tup = cp.get_tuple(_config("t1"))
+    assert tup is not None
+    assert tup.checkpoint["id"] == cid
+    assert tup.metadata == {"branch": "main"}
+
+
+def test_thread_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, fake = _build_checkpointer(monkeypatch)
+
+    cp.put(_config("alpha"), _checkpoint(1), {"step_type": "agent"}, {})
+    cp.put(_config("beta"), _checkpoint(99), {"step_type": "agent"}, {})
+
+    # Each thread has its own checkpoint; replaying one must not return
+    # the other's state.
+    alpha = cp.get_tuple(_config("alpha"))
+    beta = cp.get_tuple(_config("beta"))
+    assert alpha is not None and beta is not None
+    assert alpha.checkpoint["id"] != beta.checkpoint["id"]
+    assert fake.last_checkpoint_per_branch[("alpha", "main")] != fake.last_checkpoint_per_branch[("beta", "main")]
+
+
+def test_branch_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, fake = _build_checkpointer(monkeypatch)
+
+    cp.put(_config("t1", branch="main"), _checkpoint(1), {"step_type": "agent"}, {})
+    cp.put(_config("t1", branch="dev"), _checkpoint(2), {"step_type": "agent"}, {})
+
+    # Two branches, two distinct stored checkpoints.
+    assert len(fake.checkpoints) == 2
+
+    # Each branch's get_tuple resolves to its own state.
+    main_tup = cp.get_tuple(_config("t1", branch="main"))
+    dev_tup = cp.get_tuple(_config("t1", branch="dev"))
+    assert main_tup is not None and dev_tup is not None
+    assert main_tup.metadata["branch"] == "main"
+    assert dev_tup.metadata["branch"] == "dev"
+    assert main_tup.checkpoint["id"] != dev_tup.checkpoint["id"]
+
+
+def test_get_tuple_returns_none_when_replay_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, _fake = _build_checkpointer(monkeypatch)
+    # No checkpoint written → fake.replay raises → get_tuple returns None.
+    assert cp.get_tuple(_config("never-written")) is None
+
+
+def test_delete_thread_calls_forget(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, fake = _build_checkpointer(monkeypatch)
+
+    cp.delete_thread(_config("doomed-thread"))
+
+    assert fake.forgets == [["doomed-thread"]]
+
+
+def test_list_yields_empty_iterator(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, _fake = _build_checkpointer(monkeypatch)
+    # `list` is a stub today — documented as such in the module
+    # docstring. The contract under v0.4.5 is "returns an iterator that
+    # yields nothing"; this test pins that contract so a future
+    # implementation can flip the bit without sneaking in a default
+    # that breaks callers.
+    out = list(cp.list(_config("anything")))
+    assert out == []
+
+
+def test_put_writes_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    cp, fake = _build_checkpointer(monkeypatch)
+    # Returns None and does not touch the underlying client.
+    result = cp.put_writes(_config("t1"), [("ch", {"key": "val"})], task_id="task-1")
+    assert result is None
+    assert fake.checkpoints == {}
+    assert fake.forgets == []
+
+
+def test_asmd_checkpointer_is_back_compat_alias() -> None:
+    """`ASMDCheckpointer` and `MnemoCheckpointer` must be the same class.
+
+    Anything else (subclass, separate class with the same methods)
+    would silently break ``isinstance(x, ASMDCheckpointer)`` checks
+    in code that pre-dates v0.4.5.
+    """
+    assert ASMDCheckpointer is MnemoCheckpointer


### PR DESCRIPTION
## Summary

Closes the parked `mnemo-langgraph` v0.4.4-backlog item. Today's 2026-05-18 daily-prompt Suggestion 1 — but **honestly scoped**: the Python `ASMDCheckpointer` already implemented LangGraph 1.x's `BaseCheckpointSaver`. What was missing was (a) the canonical class name, (b) tests, (c) an example, (d) the docstring contract on stub methods, (e) the README integrations-matrix entry.

**No new Rust crate ships** — a `crates/mnemo-langgraph/` shell that re-exports MnemoEngine checkpoint primitives in a LangGraph-friendly schema would have no Rust-side consumer (LangGraph is Python). Make-work avoided.

**Workspace stays at 0.4.4** (just shipped 2026-05-17 in commit [`2a7b619`](https://github.com/sattyamjjain/mnemo/commit/2a7b6199a650af90c0922ef4bd4af64a98872e7f)). This PR populates `[Unreleased]` for the v0.4.5 cycle.

### What lands

- **`python/mnemo/checkpointer.py`** — class renamed `ASMDCheckpointer` → `MnemoCheckpointer`; `ASMDCheckpointer = MnemoCheckpointer` alias preserved at module bottom. Module docstring now documents LangGraph 1.x `BaseCheckpointSaver` coverage explicitly (primaries: `get_tuple`/`put`/`delete_thread` real; `list`/`put_writes` stubs with contracts pinned in tests).
- **`python/mnemo/__init__.py`** — soft-import block extended to export both names when langgraph dep is installed.
- **`python/mnemo/availability.py`** — probe registry adds the new `MnemoCheckpointer` name alongside the legacy `ASMDCheckpointer`.
- **`python/tests/test_langgraph_checkpointer.py`** (new) — 8 tests using a `_FakeMnemoClient` shim:
  - put → get_tuple round-trip
  - thread isolation (two threads, separate state)
  - branch round-trip (main vs dev)
  - get_tuple returns None when replay raises
  - delete_thread calls MnemoClient.forget
  - list yields empty iterator (stub contract pinned)
  - put_writes is no-op (stub contract pinned)
  - `ASMDCheckpointer is MnemoCheckpointer` (back-compat alias identity)
- **`examples/langgraph_checkpointer.py`** (new) — 5-line `StateGraph` + `MnemoCheckpointer` integration.
- **`python/README.md`** integrations row swaps `ASMDCheckpointer (LangGraph)` → `MnemoCheckpointer (LangGraph 1.x — ASMDCheckpointer is the back-compat alias)`.
- **`CHANGELOG.md`** — new `### Landing trace (2026-05-18)` + new Added entry + Parked-for-v0.4.4-backlog `mnemo-langgraph` entry **retired** with rationale + scope rebased to v0.5.x.

### Honest scope — what's NOT in this release

- **No new Rust crate.** Make-work avoided.
- **No SDK breaking change.** `ASMDCheckpointer is MnemoCheckpointer` — same class object, same import path.
- **`list` + `put_writes` stubs stay stubs.** Implementing per-thread checkpoint enumeration requires a `MnemoClient.list_checkpoints` surface that doesn't exist today — that's a v0.5.x row.
- **No workspace version bump.** Python-only + docs; workspace stays at 0.4.4. `cargo-publish` precheck will no-op on merge.

### Test plan

- [x] `python3 -m py_compile` clean on all touched Python files (langgraph dep not present in local anaconda; tests use `pytest.importorskip` so CI exercises them under the langgraph optional extra)
- [x] `cargo check --workspace --exclude mnemo-python` clean at v0.4.4
- [x] CHANGELOG structural tests green: `changelog_has_unreleased_section` + `changelog_has_landing_trace_section` (the new `### Landing trace (2026-05-18)` sub-block references commit SHAs `cde9f68` + `2a7b619`, both satisfying the `[0-9a-f]{7,40}` regex)
- [x] README structural tests green: extended banlist unchanged but still firing

### Sources

- Today's daily-prompt evidence anchor: LangChain Interrupt 2026 (May 13-14) recap — https://www.langchain.com/blog/interrupt-2026-overview — naming Delta Channels for long-running agents
- Existing adapter discovered: `python/mnemo/checkpointer.py` (`ASMDCheckpointer`)
- v0.4.4 PR merge: commit `2a7b619` (yesterday's PR #84 admin-merged at 2026-05-18T17:45:01Z this morning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)