### PR TITLE
fix(workspace): close phantom-crate drift (#74) — Planned roadmap + README claim fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,48 @@ All notable changes to Mnemo are documented in this file.
 
 ## [Unreleased]
 
-### Landing trace (2026-06-29)
+### Fixed (2026-07-03) — v0.5.5, workspace-member drift ([#74])
 
-`v0.5.4` cut today — the prior `[Unreleased]` accumulator (0.5.0 → 0.5.4 work)
-becomes the `## [0.5.4]` section below, and this fresh accumulator opens here.
-The release is cut from `main` at
-[`640b7b1`](https://github.com/sattyamjjain/mnemo/commit/640b7b1626e714b94bd3ba7146915011e1dcbf28)
-(security hardening — bearer-token auth + README truth-in-advertising); the
-authenticated-benchmark + release-drift docs commit lands on top of it as the
-`v0.5.4` tag target.
+Workspace `0.5.4 → 0.5.5` (patch bump — docs + a CI fence + version stamps; no
+dependency, engine, or protocol API change).
+
+- **chore(workspace,docs): close the phantom-crate drift ([#74]).** Seven
+  `mnemo-*` crate names asserted by the daily-prompt ledger
+  (`mnemo-envelope`, `mnemo-aas01`, `mnemo-mgt`, `mnemo-bench-cf`,
+  `mnemo-langgraph`, `mnemo-purview`, `mnemo-toolhive`) have **no source tree
+  and are not `[workspace] members`**. None were stubbed — each is an
+  external-system adapter with no consumer, and an empty shell is exactly the
+  drift the repo already *retired* `mnemo-langgraph` for. Instead every
+  reference is now truthful:
+  - **New single source of truth**
+    [`docs/roadmap/planned-crates.md`](docs/roadmap/planned-crates.md) — all
+    seven listed as **Planned / not built** (or **Retired**, for the
+    `mnemo-langgraph` Rust shell superseded by the Python `MnemoCheckpointer`).
+  - **Residual shipment-assertions corrected.** `docs/src/integrations/mcp-server.md`
+    no longer says the `mnemo-envelope` exporter "lands in v0.4.3";
+    `docs/comparisons/cloudflare-agent-memory.md` no longer says bench numbers
+    "ship in v0.4.3 as the `mnemo-bench-cf` crate" — both now say **not built**
+    and link the roadmap. The already-honest "Parked"/"Retired"/"has not been
+    built" notes elsewhere are unchanged.
+  - **CI fence against recurrence.** New
+    `crates/mnemo-cli/tests/readme_crate_claims_are_real.rs` fails the build if
+    a `mnemo-*` name in `README.md` is neither a real workspace member (matched
+    live against member dir basenames + declared package names) nor on an
+    explicit allowlist of non-crate references (PyPI/npm dist names, JSON
+    filenames, labelled sketches, prose hypotheticals). Mirrors the AAK
+    rule-count fence + the existing `readme_no_marketing_phrases` lint.
+- Version stamps bumped to `0.5.5`: `Cargo.toml`, `version_metadata` test,
+  `docs/compat/version-skew-matrix.md`.
+
+[#74]: https://github.com/sattyamjjain/mnemo/issues/74
+
+### Landing trace (2026-07-03)
+
+The `v0.5.4` release is cut and on `main` at
+[`04a1145`](https://github.com/sattyamjjain/mnemo/commit/04a1145cd50adf15c033b2dce6ac2991ff7893c0)
+(the `[0.5.4]` section below). This fresh `[Unreleased]` accumulator carries the
+v0.5.5 `#74` drift fix above; it lands via PR `fix/issue-74-workspace-member-drift`
+(no push-to-`main` publish this cut — the fix is docs + a CI fence only).
 
 ## [0.5.4] — 2026-06-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sattyamjjain/mnemo"

--- a/crates/mnemo-cli/tests/readme_crate_claims_are_real.rs
+++ b/crates/mnemo-cli/tests/readme_crate_claims_are_real.rs
@@ -1,0 +1,206 @@
+//! v0.5.5 (#74) — README crate-claim fence.
+//!
+//! Workspace-member drift is when a `mnemo-*` crate name is written into
+//! `README.md` as if it were a real, shipped crate while it has no source
+//! tree and no `[workspace] members` entry (issue #74 catalogued seven such
+//! names). This test is the recurrence gate: it extracts every `mnemo-*`
+//! token from `README.md` and fails the build unless each one is EITHER
+//!
+//!   1. a real workspace member — matched against the union of every
+//!      member directory's basename AND its declared `[package] name`
+//!      (parsed live from the root `Cargo.toml` + each member `Cargo.toml`,
+//!      so the fence tracks the workspace automatically), OR
+//!   2. on the explicit `KNOWN_NON_CRATE` allowlist below — each entry is a
+//!      real non-crate reference (a PyPI/npm distribution name, a JSON
+//!      filename, a clearly-labelled sketch, a hypothetical in prose, or the
+//!      one planned crate that the README only ever mentions in an
+//!      explicitly-negated "has not been built" context).
+//!
+//! A brand-new phantom crate name lands in neither set and fails the build,
+//! forcing the author to either wire the crate or add it to
+//! `docs/roadmap/planned-crates.md` + this allowlist with a stated reason.
+//! Mirrors the spirit of the AAK rule-count fence and the marketing-phrase
+//! lint in `readme_no_marketing_phrases.rs`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// `mnemo-*` tokens that appear in `README.md` but are deliberately NOT
+/// workspace crates. Every entry carries the reason it is legitimate.
+const KNOWN_NON_CRATE: &[(&str, &str)] = &[
+    (
+        "mnemo-db",
+        "PyPI distribution name for the Python bindings (not a Rust crate)",
+    ),
+    (
+        "mnemo-sdk",
+        "npm package short name (published as @mndfreek/mnemo-sdk)",
+    ),
+    (
+        "mnemo-grafana",
+        "filename of the bundled Grafana dashboard JSON (mnemo-grafana.json)",
+    ),
+    (
+        "mnemo-deal-agent",
+        "filename of an example agent-config JSON",
+    ),
+    (
+        "mnemo-mcp-worker",
+        "name field inside a fenced, explicitly-labelled sketch wrangler.toml",
+    ),
+    (
+        "mnemo-dreams",
+        "hypothetical primitive named only in prose, never claimed as shipped",
+    ),
+    (
+        "mnemo-primitive",
+        "hypothetical primitive named only in prose, never claimed as shipped",
+    ),
+    (
+        "mnemo-v0",
+        "token-extraction artifact from the doc filename 2026-04-25-mnemo-v0.3.4.md",
+    ),
+    (
+        "mnemo-bench-cf",
+        "planned (not built) crate; README mentions it only in explicitly-negated \
+         'has not been built — it is not a workspace member' context. Tracked in \
+         docs/roadmap/planned-crates.md (#74).",
+    ),
+];
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("repo root resolves")
+}
+
+/// Parse the `members = [ ... ]` array from the root `Cargo.toml` into a list
+/// of member paths (e.g. `crates/mnemo-core`, `bench/locomo`, `python`).
+fn workspace_member_paths(root: &Path) -> Vec<String> {
+    let cargo = std::fs::read_to_string(root.join("Cargo.toml")).expect("root Cargo.toml readable");
+    let start = cargo.find("members").expect("workspace has a members key");
+    let open = cargo[start..].find('[').expect("members array opens") + start;
+    let close = cargo[open..].find(']').expect("members array closes") + open;
+    cargo[open + 1..close]
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Read the `[package] name = "..."` from a member's `Cargo.toml`.
+fn package_name(member_dir: &Path) -> Option<String> {
+    let body = std::fs::read_to_string(member_dir.join("Cargo.toml")).ok()?;
+    for line in body.lines() {
+        let t = line.trim();
+        if let Some(rest) = t.strip_prefix("name") {
+            let rest = rest.trim_start();
+            if let Some(rest) = rest.strip_prefix('=') {
+                return Some(rest.trim().trim_matches('"').to_string());
+            }
+        }
+    }
+    None
+}
+
+/// The set of identifiers that legitimately name a real workspace crate:
+/// each member directory's basename plus its declared package name.
+fn real_crate_identifiers(root: &Path) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    for member in workspace_member_paths(root) {
+        if let Some(base) = Path::new(&member).file_name().and_then(|s| s.to_str()) {
+            ids.insert(base.to_string());
+        }
+        if let Some(name) = package_name(&root.join(&member)) {
+            ids.insert(name);
+        }
+    }
+    ids
+}
+
+/// Extract every distinct `mnemo-<[a-z0-9-]+>` token from `text`.
+fn mnemo_tokens(text: &str) -> BTreeSet<String> {
+    let bytes = text.as_bytes();
+    let mut out = BTreeSet::new();
+    let needle = b"mnemo-";
+    let mut i = 0;
+    while i + needle.len() <= bytes.len() {
+        if &bytes[i..i + needle.len()] == needle {
+            let mut j = i + needle.len();
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'-' {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            let token = text[i..j].trim_end_matches('-').to_string();
+            // Require at least one char after the `mnemo-` prefix.
+            if token.len() > needle.len() {
+                out.insert(token);
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+#[test]
+fn readme_mnemo_crate_names_are_real_members_or_allowlisted() {
+    let root = repo_root();
+    let readme = std::fs::read_to_string(root.join("README.md")).expect("README.md readable");
+
+    let real = real_crate_identifiers(&root);
+    let allow: BTreeSet<&str> = KNOWN_NON_CRATE.iter().map(|(name, _)| *name).collect();
+
+    let mut violations: Vec<String> = Vec::new();
+    for token in mnemo_tokens(&readme) {
+        if real.contains(&token) || allow.contains(token.as_str()) {
+            continue;
+        }
+        violations.push(token);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "README.md references mnemo-* crate name(s) that are neither a real \
+         workspace member nor an allowlisted non-crate reference: {violations:?}. \
+         Either add the crate under crates/ + [workspace] members, or — if it is \
+         aspirational — add it to docs/roadmap/planned-crates.md and to \
+         KNOWN_NON_CRATE in this test with the reason it is not a crate. This \
+         fence exists so issue #74 (workspace-member drift) cannot silently return."
+    );
+}
+
+#[test]
+fn allowlist_has_no_stale_entries() {
+    // If an allowlisted name later becomes a real workspace member, or stops
+    // appearing in the README, drop it from KNOWN_NON_CRATE so the list stays
+    // an accurate ledger rather than accumulating dead exceptions.
+    let root = repo_root();
+    let readme = std::fs::read_to_string(root.join("README.md")).expect("README.md readable");
+    let tokens = mnemo_tokens(&readme);
+    let real = real_crate_identifiers(&root);
+
+    let mut stale: Vec<String> = Vec::new();
+    for (name, _reason) in KNOWN_NON_CRATE {
+        if !tokens.contains(*name) {
+            stale.push(format!("{name} (no longer in README)"));
+        } else if real.contains(*name) {
+            stale.push(format!(
+                "{name} (now a real workspace member — remove the exception)"
+            ));
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "KNOWN_NON_CRATE has stale entries that should be removed: {stale:?}."
+    );
+}

--- a/crates/mnemo-core/tests/version_metadata.rs
+++ b/crates/mnemo-core/tests/version_metadata.rs
@@ -10,11 +10,11 @@
 //! [docs/compat/version-skew-matrix.md](../../docs/compat/version-skew-matrix.md).
 
 #[test]
-fn cargo_pkg_version_matches_v0_5_4() {
+fn cargo_pkg_version_matches_v0_5_5() {
     assert_eq!(
         env!("CARGO_PKG_VERSION"),
-        "0.5.4",
-        "mnemo-core CARGO_PKG_VERSION drifted from the v0.5.4 cut. \
+        "0.5.5",
+        "mnemo-core CARGO_PKG_VERSION drifted from the v0.5.5 cut. \
          Bump `workspace.package.version` in /Cargo.toml AND update \
          docs/compat/version-skew-matrix.md to match."
     );

--- a/docs/comparisons/cloudflare-agent-memory.md
+++ b/docs/comparisons/cloudflare-agent-memory.md
@@ -1,10 +1,12 @@
 # mnemo vs Cloudflare Agent Memory — long-form comparison
 
 > Living doc, last updated 2026-05-03 for the v0.4.2 cut. The full
-> bench numbers ship in v0.4.3 as the `mnemo-bench-cf` crate. Until
-> then, this file is the **contract** that the bench will produce
-> against — every "TBD" placeholder below corresponds to a metric the
-> v0.4.3 harness will fill in.
+> bench numbers were planned to ship as the `mnemo-bench-cf` crate,
+> which is **not built** — it is not a workspace member and has never
+> been run (see [`docs/roadmap/planned-crates.md`](../roadmap/planned-crates.md)).
+> This file is therefore a design **contract** only: every "TBD"
+> placeholder below corresponds to a metric the harness *would* fill
+> in, not a result.
 
 ## Why this comparison exists
 

--- a/docs/compat/version-skew-matrix.md
+++ b/docs/compat/version-skew-matrix.md
@@ -1,6 +1,9 @@
 # Mnemo Version Skew Matrix
 
-> Updated 2026-06-27 for the v0.5.4 cut (bearer-token auth on REST + gRPC via
+> Updated 2026-07-03 for the v0.5.5 cut (workspace-member drift fix, #74 —
+> phantom crate references removed / relabelled Planned, a `README.md`
+> crate-claim CI fence added; docs-and-tests only, no dependency or API
+> change from v0.5.4). The v0.5.4 cut added bearer-token auth on REST + gRPC via
 > `MNEMO_AUTH_TOKEN` → `401`/`UNAUTHENTICATED`, else open + warn; README
 > security claims aligned to wired behavior + a "what is/isn't enforced today"
 > table). No engine/protocol API break — additive `router_with_auth`. The
@@ -21,7 +24,8 @@ source-of-truth — see [CHANGELOG](../../CHANGELOG.md)).
 
 | `mnemo` (Cargo workspace) | `rmcp` | `tantivy` | `usearch` | `duckdb` | `pgvector` | `sqlx` | Cloudflare substrate ³ |
 |---|---|---|---|---|---|---|---|
-| **0.5.4** (2026-06-27) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
+| **0.5.5** (2026-07-03) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
+| 0.5.4 (2026-06-27) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.5.3 (2026-06-23) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.5.2 (2026-06-22) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.5.1 (2026-06-21) | 1.3 | 0.26 | 2.21 | 1.10502.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
@@ -40,7 +44,8 @@ source-of-truth — see [CHANGELOG](../../CHANGELOG.md)).
 
 | `mnemo` | Python SDK (`mnemo-db`) | TS SDK (`@mndfreek/mnemo-sdk`) | Go SDK (`mnemo.Version`) | `mcp-python` ⁵ | `mcp-go` ⁵ | `mcp-ruby` ⁵ | `mcp-csharp` ⁵ |
 |---|---|---|---|---|---|---|---|
-| **0.5.4** (2026-06-27) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
+| **0.5.5** (2026-07-03) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
+| 0.5.4 (2026-06-27) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
 | 0.5.3 (2026-06-23) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
 | 0.5.2 (2026-06-22) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
 | 0.5.1 (2026-06-21) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |

--- a/docs/roadmap/planned-crates.md
+++ b/docs/roadmap/planned-crates.md
@@ -1,0 +1,55 @@
+# Planned crates — not yet implemented
+
+> **Status: PLANNED. None of the crates on this page exist under `crates/`,
+> none are in `[workspace] members`, and none ship any code today.** This
+> page is the single source of truth for crate names that appear in the
+> daily-prompt ledger, comparison docs, and integration design notes but
+> have **not** been built. If a name is on this list, treat every mention of
+> it anywhere in the repo as aspirational, not shipped.
+
+This file closes the loop on
+[#74](https://github.com/sattyamjjain/mnemo/issues/74) — "workspace-member
+drift: prompt-referenced crates not in `[workspace] members`." The rule going
+forward is truth-in-advertising: **either a crate exists and is wired, or its
+only home is this Planned list.** A CI guard
+(`crates/mnemo-cli/tests/readme_crate_claims_are_real.rs`) fails the build if a
+`mnemo-*` crate name is presented in `README.md` without being a real
+workspace member, so this drift cannot silently return.
+
+## Why these were not stubbed
+
+Each entry below is an adapter to an external system (Purview, ToolHive,
+LangGraph, OWASP AAS01, SecureAuth MGT, an OTel envelope kind, a Cloudflare
+bench substrate). An empty Rust shell with no downstream consumer is exactly
+what the workspace already **retired** for `mnemo-langgraph` (see the
+`## [Unreleased]` / v0.4.4-backlog CHANGELOG note): a shell that compiles but
+does nothing is drift wearing a workspace-member badge. So the honest state is
+a labelled roadmap entry, not a placeholder crate. Any of these graduates to a
+real `crates/<name>/` + `[workspace] members` entry only when there is a
+concrete design + a consumer that wires it in.
+
+## The list
+
+| Crate | Intended purpose | Status | Tracking |
+|---|---|---|---|
+| `mnemo-envelope` | OTel exporter envelope kind (`EnvelopeKind::FetcherAttestation`, agent-vs-human authorship tag) | Planned — not built | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+| `mnemo-aas01` | OWASP AAS01 detector surface | Planned — not built | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+| `mnemo-mgt` | SecureAuth Trust Registry adapter | Planned — not built | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+| `mnemo-bench-cf` | Cloudflare Agent Memory bench harness (KV+Vectorize vs DO-Facets SQLite) | Planned — not built | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+| `mnemo-langgraph` | LangGraph Rust checkpoint adapter | **Retired** — superseded by the Python `MnemoCheckpointer` (`python/mnemo/checkpointer.py`); no Rust consumer | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+| `mnemo-purview` | Microsoft Purview audit-log adapter | Planned — not built | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+| `mnemo-toolhive` | Stacklok ToolHive Registry sync | Planned — not built | [#74](https://github.com/sattyamjjain/mnemo/issues/74) |
+
+## What *does* exist (so the contrast is unambiguous)
+
+- The functional equivalent of `mnemo-langgraph` ships today as the Python
+  `MnemoCheckpointer` (back-compat alias `ASMDCheckpointer`) in
+  `python/mnemo/checkpointer.py` — that is the wired path; the Rust crate is
+  retired, not pending.
+- The Cloudflare comparison is a **design contract** only:
+  [`docs/comparisons/cloudflare-agent-memory.md`](../comparisons/cloudflare-agent-memory.md)
+  and [`docs/src/integrations/cloudflare-workers-deploy.md`](../src/integrations/cloudflare-workers-deploy.md)
+  describe what `mnemo-bench-cf` *would* measure. Every number there is a `TBD`
+  placeholder, not a run result.
+
+_Last reconciled: 2026-07-03 (v0.5.5)._

--- a/docs/src/integrations/mcp-server.md
+++ b/docs/src/integrations/mcp-server.md
@@ -174,8 +174,9 @@ and the three integration tests under
 - Per-tool-method enforcement of the role filter at `tools/call`
   dispatch — the manifest schema, the filter trait/impl, and the
   audit emission are shipped in v0.4.2; threading the filter through
-  every `MnemoServer` tool method body lands in v0.4.3 with the
-  `mnemo-envelope` exporter.
+  every `MnemoServer` tool method body is still pending. The
+  `mnemo-envelope` OTel exporter kind that a later step depends on is
+  **not built** — see [`docs/roadmap/planned-crates.md`](../../roadmap/planned-crates.md).
 
 For the threat model and the full design notes, see the rationale at
 the top of `crates/mnemo-cli/src/safe_spawn.rs`.


### PR DESCRIPTION
## Summary

Closes #74 — the workspace-member drift where 7 prompt-referenced `mnemo-*`
crate names have **no source tree** and are **not** in `[workspace] members`.
Truth-in-advertising fix: no phantom crates. **None were stubbed** — each of the
seven is an external-system adapter with no consumer, and an empty compiling
shell is exactly the drift this repo already *retired* `mnemo-langgraph` for.
Instead every reference is made truthful and a CI fence prevents recurrence.

### Decision per crate — all 7 → labelled Planned (outcome b), none stubbed

| Crate | Outcome |
|---|---|
| `mnemo-envelope` | Planned / not built — roadmap only |
| `mnemo-aas01` | Planned / not built — roadmap only |
| `mnemo-mgt` | Planned / not built — roadmap only |
| `mnemo-bench-cf` | Planned / not built — roadmap only (README already negates it) |
| `mnemo-langgraph` | **Retired** — superseded by the Python `MnemoCheckpointer` |
| `mnemo-purview` | Planned / not built — roadmap only |
| `mnemo-toolhive` | Planned / not built — roadmap only |

### Changes

- **New single source of truth:** `docs/roadmap/planned-crates.md` lists all
  seven as Planned/Retired with purpose + #74 link, and explains why an empty
  shell is not the honest option.
- **Residual shipment-assertions corrected** (the only two docs that still
  implied a shipment schedule that never happened):
  - `docs/src/integrations/mcp-server.md` — `mnemo-envelope` exporter no longer
    "lands in v0.4.3"; now "not built" + roadmap link.
  - `docs/comparisons/cloudflare-agent-memory.md` — bench numbers no longer
    "ship in v0.4.3 as the `mnemo-bench-cf` crate"; now "not built" + roadmap link.
  - Already-honest "Parked"/"Retired"/"has not been built" notes elsewhere are
    unchanged (they were accurate history).
- **CI fence (recurrence gate):** `crates/mnemo-cli/tests/readme_crate_claims_are_real.rs`
  fails the build if a `mnemo-*` name in `README.md` is neither a real workspace
  member (matched **live** against member dir basenames + declared `[package]
  name`, so it tracks the workspace automatically) nor on an explicit
  `KNOWN_NON_CRATE` allowlist (PyPI `mnemo-db`, npm `mnemo-sdk`, JSON filenames,
  the labelled wrangler sketch, prose hypotheticals, and the negated
  `mnemo-bench-cf`). Second test rejects stale allowlist entries. Mirrors the
  AAK rule-count fence + the existing `readme_no_marketing_phrases` lint.
- **Version** `0.5.4 → 0.5.5` (patch): `Cargo.toml`, `version_metadata` test,
  `docs/compat/version-skew-matrix.md`. CHANGELOG `[Unreleased]` entry added.

### Test plan

- `cargo build --workspace` ✅ (excl. `mnemo-python` PyO3 + `mnemo-golem-{wit,host}` WASM, per CI)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ — incl. the new fence (`2 passed`) and the bumped `version_metadata`
- `cargo fmt --all -- --check` ✅

### Not in this PR (by design)

- **No crates.io / PyPI / npm publish.** This is an internal honesty fix; it
  lands as a PR (not a push to `main`), so the version-gated publish workflows
  do not fire. `KILL_CRITERIA.md` (untracked) is intentionally not committed.
