### PR TITLE
bench: BEAM benchmark (reproduced vs self-reported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to Mnemo are documented in this file.
 
 ## [Unreleased]
 
+### Added (2026-07-04) — v0.5.8, reproducible BEAM-style multi-hop/open-domain retrieval bench
+
+Workspace `0.5.7 → 0.5.8` (patch bump — a new bench bin + a shared stats helper
++ docs; no engine/protocol API change).
+
+- **bench(locomo): reproducible BEAM-style multi-hop/open-domain number over
+  hybrid recall.** New bin
+  [`bench/locomo/src/bin/beam_bench.rs`](bench/locomo/src/bin/beam_bench.rs)
+  (`cargo run --release -p mnemo-locomo-bench --bin beam_bench`) runs two
+  BEAM-style subtasks — multi-hop (answer reachable only via a `related_to`
+  graph edge) and open-domain (gold among same-schema distractors) — over
+  mnemo's default hybrid `auto`/RRF recall (semantic + BM25 + graph + recency),
+  reporting per-subtask accuracy with a **Wilson 95%** interval.
+  - **Deterministic + offline by default:** a hashed bag-of-tokens embedder (no
+    network, no LLM), fixed seed `0xbea320262026`, 100 queries × 5 pooled
+    repeats/subtask (repeats pooled to average the USearch HNSW approximate-NN
+    noise floor into the CI — the same treatment `semantic_recall_bench`
+    documents). A real-embedder path is gated behind `--ollama-model` and fails
+    loud if Ollama is unreachable — never a silent/unreproducible number.
+  - **Result (this run):** `multi_hop` **0.6%** (3/500, [0.2%, 1.7%]),
+    `open_domain` **68.6%** (343/500, [64.4%, 72.5%]). The low multi-hop figure
+    is reported as-is — default `auto` RRF barely surfaces a graph-only answer
+    against lexically-equivalent distractors; `graph`/`reconstruct` are the
+    multi-hop tools.
+  - **Honest framing (no over-claim):** `bench/RESULTS.md` + README add a BEAM
+    row with an explicit **reproduced (this fixture) vs. self-reported
+    (upstream)** column and a note that self-reported memory scores (e.g.
+    Hindsight BEAM 64.1% @ 10M tokens) are a vendor-run **upper bound**, not
+    independently reproduced, and **not comparable** to a small synthetic
+    fixture. No "first"/"best" claim.
+  - **Refactor:** extracted the shared `wilson_95` CI helper into
+    `mnemo_locomo_bench::stats` (reused by `beam_bench` and `asi06_resistance`
+    instead of a per-bin copy). Also corrected `bench/RESULTS.md`'s stale
+    backend note (pgvector semantic recall is implemented as of v0.5.7, #99).
+
 ### Fixed (2026-07-04) — v0.5.7, real pgvector ANN search on the Postgres backend ([#99])
 
 Workspace `0.5.6 → 0.5.7` (patch bump — implements a previously-stubbed backend

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sattyamjjain/mnemo"

--- a/README.md
+++ b/README.md
@@ -743,6 +743,25 @@ layer surfaces the right memory ~74% of the time at k=1 with a real embedder, fu
 reproducible from the command above. Closing the gap to a comparable QA-accuracy row
 is tracked as the open end-to-end-eval work, not something we are reporting here.
 
+### BEAM-style multi-hop / open-domain (reproduced vs. self-reported)
+
+A separate **deterministic** number over mnemo's default hybrid recall
+(`strategy="auto"`), offline embedder, no LLM — 100 queries × 5 pooled repeats/subtask,
+top-5, seed `0xbea320262026`, via [`beam_bench`](bench/locomo/src/bin/beam_bench.rs):
+
+| subtask | **reproduced** (this fixture) | self-reported (upstream) |
+|---|---:|---:|
+| `multi_hop` (answer only via a graph edge) | **0.6%** (3/500) [95% 0.2–1.7%] | — (BEAM reports one overall score) |
+| `open_domain` (gold among same-schema distractors) | **68.6%** (343/500) [95% 64.4–72.5%] | Hindsight BEAM **64.1%** @ 10M tokens ([source](https://hindsight.vectorize.io/blog/2026/04/02/beam-sota)) |
+
+**Not a ranking.** The reproduced figures are on a *small synthetic fixture* with a
+lexical offline embedder and no LLM judge; upstream 64.1% is the real 10M-token,
+LLM-graded BEAM. Self-reported memory scores are a vendor-run **upper bound** (not
+independently reproduced) — so the columns are **not comparable**. The low `multi_hop`
+figure is honest, not a bug: default `auto` RRF barely surfaces an answer reachable
+only through a graph edge (the `graph` / `reconstruct` strategies target multi-hop).
+No "first"/"best" claim. Full note + reproduce command: [`bench/RESULTS.md`](bench/RESULTS.md).
+
 **Phase-aware cost attribution + agent-memory characterization scorecard (bench-only).** Anchored on [arXiv:2606.06448](https://arxiv.org/abs/2606.06448) (*Agent Memory: Characterization and System Implications of Stateful Long-Horizon Workloads*). The new [`phase_cost`](bench/locomo/src/bin/phase_cost.rs) bin splits every benchmark scenario's cost into the paper's **three phases** — **construction** (remember-path: embedding calls, prefill tokens, write latency), **retrieval** (recall-path: ANN + BM25 + graph + RRF latency, query tokens), and **generation** (downstream, *estimated* — mnemo does not generate) — and emits a per-phase table (tokens, wall-ms, $-estimate at configurable per-1K rates) per scenario. The `--scorecard-2606-06448` flag instead renders mnemo's PASS / PARTIAL / FAIL position against the paper's 10 §5 recommendations (quoted verbatim) as a 10-row table; mnemo currently scores **5 PASS · 5 PARTIAL · 0 FAIL** (PASS on the latency / feasibility / compaction recommendations R5/R7/R8/R9/R10; PARTIAL on the operator-side lifecycle-policy ones R1–R4/R6). Run via `cargo run --release --bin phase_cost -p mnemo-locomo-bench` (add `-- --scorecard-2606-06448` for the scorecard). **This is bench-only** — no access protocol (MCP / REST / gRPC / pgwire) and no retrieval default is touched; token counts are `ceil(chars/4)` estimates and the generation phase is never an LLM call. Sample per-phase table (default rates, 64 records / 16 queries, `NoopEmbedding`):
 
 ```

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -77,9 +77,39 @@ with Engram or any hosted memory service. The full per-mode tables, the
 held-out RRF sweep, and the raw JSON live at
 [`bench/locomo/results/semantic_recall_2026-06-22.md`](locomo/results/semantic_recall_2026-06-22.md).
 
+## BEAM-style retrieval — reproduced vs. self-reported
+
+A second, **deterministic** number over mnemo's default hybrid recall
+(`strategy="auto"`: semantic + BM25 + graph-expansion + recency, RRF-fused) on
+two BEAM-style subtasks. Run with the offline hashed embedder (no network, no
+LLM), 100 queries × 5 pooled repeats/subtask, top-5, seed `0xbea320262026`
+(2026-07-04):
+
+| subtask | **reproduced** (this run, seed `0xbea320262026`) | self-reported (upstream) |
+|---|---:|---:|
+| `multi_hop` (graph-linked answer, no shared query token) | **0.6%** (3/500) [Wilson 95% 0.2%–1.7%] | — (BEAM reports one overall accuracy, not per-subtask) |
+| `open_domain` (gold among same-schema distractors) | **68.6%** (343/500) [Wilson 95% 64.4%–72.5%] | Hindsight BEAM **64.1%** @ 10M tokens ([source](https://hindsight.vectorize.io/blog/2026/04/02/beam-sota)) |
+
+**Honesty note — do not read the two columns as a ranking.** The reproduced
+numbers are on a *small synthetic fixture* with a lexical offline embedder and
+**no LLM judge**; the upstream **64.1%** is on the real BEAM benchmark (10M-token
+corpus, LLM-graded). Self-reported memory scores are a vendor-run **upper
+bound** — not independently reproduced across labs (the reproducibility gap the
+[Hindsight paper](https://arxiv.org/abs/2512.12818) itself flags for pre-LoCoMo
+memory evals) — and a synthetic-fixture number is **not comparable** to it. The
+low `multi_hop` figure is an honest result, not a bug: mnemo's default `auto`
+RRF barely surfaces an answer reachable *only* through a graph edge against
+lexically-equivalent distractors — the `graph` / `reconstruct` strategies are
+the tools aimed at multi-hop (see [`bench/locomo/src/bin/reconstruct_ab.rs`](locomo/src/bin/reconstruct_ab.rs)).
+No "first" / "best" claim is made. Reproduce:
+`cargo run --release -p mnemo-locomo-bench --bin beam_bench`
+(writes `bench/locomo/results/beam_<date>.{md,json}`).
+
 ## Backend note
 
-Semantic recall is supported on the **DuckDB + USearch** backend (used above).
-The PostgreSQL/pgvector ANN path is **not** implemented and **hard-errors**
-rather than silently returning empty results — see
-`crates/mnemo-postgres/src/pgvector_index.rs`. Use DuckDB for semantic recall.
+Semantic recall is supported on **both** backends: **DuckDB + USearch**
+(default, used for the headline above) and, since v0.5.7,
+**PostgreSQL + pgvector** — the pgvector HNSW ANN path is implemented
+(`crates/mnemo-postgres/src/pgvector_index.rs`, [#99](https://github.com/sattyamjjain/mnemo/issues/99));
+if the pgvector extension is genuinely absent it still hard-errors rather than
+returning empty. The numbers above were measured on the DuckDB backend.

--- a/bench/locomo/Cargo.toml
+++ b/bench/locomo/Cargo.toml
@@ -46,6 +46,10 @@ path = "src/bin/reconstruct_ab.rs"
 name = "asi06_resistance"
 path = "src/bin/asi06_resistance.rs"
 
+[[bin]]
+name = "beam_bench"
+path = "src/bin/beam_bench.rs"
+
 [dependencies]
 mnemo-core = { workspace = true }
 serde = { workspace = true }

--- a/bench/locomo/results/beam_2026-07-04.json
+++ b/bench/locomo/results/beam_2026-07-04.json
@@ -1,0 +1,37 @@
+{
+  "bench": "beam_bench",
+  "date": "2026-07-04",
+  "distractors_per_gold": 4,
+  "embedder": "hash-bag-of-tokens (deterministic, offline)",
+  "hnsw_noise_note": "vector lane is USearch HNSW (approximate NN); repeats pooled to average the run-to-run ranking noise floor into the Wilson CI",
+  "note": "synthetic deterministic fixture; NOT the upstream 10M-token BEAM dataset; no LLM judge",
+  "queries_per_repeat": 100,
+  "repeats": 5,
+  "results": [
+    {
+      "accuracy": 0.006,
+      "accuracy_ci95_high": 0.01749025210405338,
+      "accuracy_ci95_low": 0.002042596271960237,
+      "hits": 3,
+      "queries": 500,
+      "subtask": "multi_hop"
+    },
+    {
+      "accuracy": 0.686,
+      "accuracy_ci95_high": 0.7251321441639025,
+      "accuracy_ci95_low": 0.6440316011844003,
+      "hits": 343,
+      "queries": 500,
+      "subtask": "open_domain"
+    }
+  ],
+  "seed": 209607828316198,
+  "style": "BEAM-style multi-hop + open-domain retrieval over hybrid auto/RRF recall",
+  "top_k": 5,
+  "upstream_self_reported": {
+    "beam_accuracy": 0.641,
+    "scale": "10M tokens",
+    "source": "https://hindsight.vectorize.io/blog/2026/04/02/beam-sota",
+    "system": "Hindsight"
+  }
+}

--- a/bench/locomo/results/beam_2026-07-04.md
+++ b/bench/locomo/results/beam_2026-07-04.md
@@ -1,0 +1,13 @@
+# BEAM-style retrieval bench — multi-hop + open-domain (hybrid auto/RRF)
+
+> 2026-07-04 — reproducible retrieval bench over mnemo's default hybrid recall (`strategy="auto"`: semantic + BM25 + graph-expansion + recency, RRF-fused). **Synthetic deterministic fixture, no LLM** — this is NOT the upstream BEAM dataset. See the honesty note in [`bench/RESULTS.md`](../../RESULTS.md).
+
+- **100 queries × 5 repeats/subtask** (n=500), 4 distractors/gold, top-5, seed `0xbea320262026`, embedder `hash-bag-of-tokens (deterministic, offline)`.
+- *Accuracy* = fraction of queries whose gold memory is in the top-5 (Wilson 95%). Repeats are pooled to average the USearch HNSW approximate-NN ranking noise floor into the CI (same treatment `semantic_recall_bench` documents).
+
+| subtask | queries | hits | **accuracy** (95% Wilson) |
+|---|---:|---:|---:|
+| `multi_hop` (graph-linked answer, no shared query token) | 500 | 3 | **0.6%** [0.2%, 1.7%] |
+| `open_domain` (gold among same-schema distractors) | 500 | 343 | **68.6%** [64.4%, 72.5%] |
+
+**Reproduced vs self-reported.** These numbers are reproduced on *this* synthetic fixture. Upstream **BEAM** (Hindsight, self-reported **64.1%** at 10M tokens, [source](https://hindsight.vectorize.io/blog/2026/04/02/beam-sota)) runs a vastly larger real corpus scored by an LLM judge. Self-reported memory scores are an **upper bound** (vendor-run, not independently reproduced across labs), and our fixture number is **not comparable** to it — do not read the two as a ranking. Reproduce: `cargo run --release -p mnemo-locomo-bench --bin beam_bench`.

--- a/bench/locomo/src/bin/asi06_resistance.rs
+++ b/bench/locomo/src/bin/asi06_resistance.rs
@@ -67,6 +67,7 @@ use mnemo_core::query::recall::RecallRequest;
 use mnemo_core::query::remember::RememberRequest;
 use mnemo_core::search::tantivy_index::TantivyFullTextIndex;
 use mnemo_core::storage::duckdb::DuckDbStorage;
+use mnemo_locomo_bench::stats::wilson_95;
 
 const AGENT: &str = "asi06-resistance-agent";
 /// Fixed default seed → fully reproducible run.
@@ -213,22 +214,6 @@ async fn recall_hits_poison(
     req.limit = Some(k);
     let resp = engine.recall(req).await.unwrap();
     resp.memories.iter().any(|m| m.id == poison_id)
-}
-
-/// Wilson 95% score interval for `successes`/`n` (z = 1.96). Returns
-/// `(low, high)` clamped to `[0, 1]`.
-fn wilson_95(successes: usize, n: usize) -> (f64, f64) {
-    if n == 0 {
-        return (0.0, 0.0);
-    }
-    let z = 1.959_963_984_540_054_f64;
-    let n = n as f64;
-    let p = successes as f64 / n;
-    let z2 = z * z;
-    let denom = 1.0 + z2 / n;
-    let center = (p + z2 / (2.0 * n)) / denom;
-    let margin = (z / denom) * (p * (1.0 - p) / n + z2 / (4.0 * n * n)).sqrt();
-    ((center - margin).max(0.0), (center + margin).min(1.0))
 }
 
 struct ClassResult {

--- a/bench/locomo/src/bin/beam_bench.rs
+++ b/bench/locomo/src/bin/beam_bench.rs
@@ -1,0 +1,568 @@
+//! BEAM-style multi-hop + open-domain retrieval bench over mnemo's hybrid recall.
+//!
+//! # What this is
+//!
+//! A **reproducible, deterministic** micro-benchmark that exercises mnemo's
+//! default hybrid retrieval (semantic vector + BM25 + graph-expansion + recency,
+//! fused with RRF — `strategy = "auto"`) on two BEAM-style subtasks:
+//!
+//! * **multi-hop** — the gold answer lives in a memory that is *graph-linked*
+//!   (`related_to`) to a memory the query matches, but shares **no** entity
+//!   token with the query. Answering requires the hop
+//!   `query → head → linked detail`, which only the graph-expansion lane of
+//!   `auto` recall can bridge.
+//! * **open-domain** — the gold memory sits among many same-schema distractors;
+//!   the query must surface it from the whole corpus.
+//!
+//! Accuracy per subtask = fraction of queries whose gold memory is in the
+//! top-`k`, reported with a **Wilson 95%** interval
+//! ([`mnemo_locomo_bench::stats::wilson_95`], shared with the other benches).
+//!
+//! # This is NOT the BEAM dataset
+//!
+//! BEAM (Hindsight's [10M-token memory benchmark](https://hindsight.vectorize.io/blog/2026/04/02/beam-sota),
+//! self-reported SOTA **64.1%**) runs a huge external corpus scored by an LLM
+//! judge. This bin runs a **small synthetic fixture** with a deterministic
+//! offline embedder and **no LLM**. The number here measures whether mnemo's
+//! retrieval *mechanism* recovers multi-hop / open-domain gold on a controlled
+//! fixture — it is **not comparable** to the upstream self-reported score and
+//! must never be read as a ranking against it (see `bench/RESULTS.md`).
+//!
+//! # Embedder
+//!
+//! Default: a **deterministic offline** hashed-bag-of-tokens embedder — no
+//! network, identical output every run, CI-safe. Pass `--ollama-model <name>`
+//! for a real semantic embedder (higher fidelity, **not** deterministic); like
+//! the LongMemEval bench it fails loud if Ollama is unreachable rather than
+//! emitting a silent number.
+//!
+//! Reproduce: `cargo run --release -p mnemo-locomo-bench --bin beam_bench`
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use clap::Parser;
+
+use mnemo_core::embedding::EmbeddingProvider;
+use mnemo_core::error::{Error, Result as MnResult};
+use mnemo_core::index::usearch::UsearchIndex;
+use mnemo_core::query::MnemoEngine;
+use mnemo_core::query::recall::RecallRequest;
+use mnemo_core::query::remember::RememberRequest;
+use mnemo_core::search::tantivy_index::TantivyFullTextIndex;
+use mnemo_core::storage::duckdb::DuckDbStorage;
+use mnemo_locomo_bench::stats::wilson_95;
+
+const AGENT: &str = "beam-bench-agent";
+/// Fixed default seed → fully reproducible run.
+const DEFAULT_SEED: u64 = 0xBEA3_2026_2026_u64;
+/// Deterministic offline embedder width.
+const EMBED_DIM: usize = 128;
+
+#[derive(Parser, Debug)]
+#[command(name = "beam_bench")]
+struct Cli {
+    /// Queries (and gold memories) per subtask, per repeat.
+    #[arg(long, default_value_t = 100)]
+    queries: usize,
+    /// In-process repeats (fresh fixture each) pooled into one number. The
+    /// vector lane is an approximate-NN index (USearch HNSW) whose ranking has
+    /// a small run-to-run noise floor; pooling repeats stabilises the reported
+    /// rate the way `semantic_recall_bench` does. `queries * repeats` = n.
+    #[arg(long, default_value_t = 5)]
+    repeats: usize,
+    /// Distractor memories per gold (same-schema noise the gold competes with).
+    #[arg(long, default_value_t = 4)]
+    distractors: usize,
+    /// Top-k cutoff for "was the gold recalled".
+    #[arg(long, default_value_t = 5)]
+    k: usize,
+    /// Deterministic seed.
+    #[arg(long, default_value_t = DEFAULT_SEED)]
+    seed: u64,
+    /// Output directory for the Markdown + JSON report.
+    #[arg(long, default_value = "bench/locomo/results")]
+    out_dir: PathBuf,
+    /// Use a real Ollama embedder (e.g. `nomic-embed-text`) instead of the
+    /// deterministic offline one. Higher fidelity, but NOT deterministic and
+    /// NOT CI-safe; fails loud if Ollama is unreachable.
+    #[arg(long)]
+    ollama_model: Option<String>,
+    /// Ollama base URL (used only with `--ollama-model`).
+    #[arg(long, default_value = "http://localhost:11434")]
+    ollama_url: String,
+}
+
+/// splitmix64 — tiny deterministic PRNG (no `rand` dep, stable across platforms
+/// so the published number is reproducible).
+struct SplitMix64(u64);
+impl SplitMix64 {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    /// A short lowercase token, deterministic in the draw.
+    fn token(&mut self) -> String {
+        format!("{:08x}", self.next_u64() & 0xFFFF_FFFF)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Embedders
+// ---------------------------------------------------------------------------
+
+fn fnv1a(t: &str) -> u64 {
+    let mut h = 0xcbf2_9ce4_8422_2325_u64;
+    for b in t.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Deterministic, offline, network-free embedder: L2-normalised hashed
+/// bag-of-tokens. Overlapping vocabulary → higher cosine, identical every run.
+/// It is lexical (no synonymy) — that is the point: reproducible, not clever.
+struct HashEmbedding {
+    dim: usize,
+}
+
+impl HashEmbedding {
+    fn embed_sync(&self, text: &str) -> Vec<f32> {
+        let mut v = vec![0.0f32; self.dim];
+        for tok in text
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .filter(|s| !s.is_empty())
+        {
+            let idx = (fnv1a(&tok.to_ascii_lowercase()) as usize) % self.dim;
+            v[idx] += 1.0;
+        }
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        v
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for HashEmbedding {
+    async fn embed(&self, text: &str) -> MnResult<Vec<f32>> {
+        Ok(self.embed_sync(text))
+    }
+    async fn embed_batch(&self, texts: &[&str]) -> MnResult<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|t| self.embed_sync(t)).collect())
+    }
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+}
+
+/// Real semantic embedder via a local Ollama server (gated behind
+/// `--ollama-model`). Fails loud, never silent — matching the LongMemEval bench.
+struct OllamaEmbedding {
+    client: reqwest::Client,
+    url: String,
+    model: String,
+    dim: usize,
+}
+
+impl OllamaEmbedding {
+    async fn connect(url: String, model: String) -> MnResult<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| Error::Embedding(e.to_string()))?;
+        let mut me = Self {
+            client,
+            url,
+            model,
+            dim: 0,
+        };
+        // Probe dimensionality once so the index is sized correctly.
+        let probe = me.embed("dimension probe").await?;
+        me.dim = probe.len();
+        Ok(me)
+    }
+    async fn embed_one(&self, text: &str) -> MnResult<Vec<f32>> {
+        let resp = self
+            .client
+            .post(format!("{}/api/embeddings", self.url))
+            .json(&serde_json::json!({ "model": self.model, "prompt": text }))
+            .send()
+            .await
+            .map_err(|e| {
+                Error::Embedding(format!(
+                    "{e} — is Ollama running and the model pulled? Try: `ollama pull {}`",
+                    self.model
+                ))
+            })?;
+        if !resp.status().is_success() {
+            return Err(Error::Embedding(format!(
+                "ollama returned HTTP {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| Error::Embedding(format!("ollama response decode: {e}")))?;
+        let embedding = body
+            .get("embedding")
+            .and_then(|e| e.as_array())
+            .ok_or_else(|| Error::Embedding("ollama response missing `embedding`".to_string()))?
+            .iter()
+            .map(|v| v.as_f64().unwrap_or(0.0) as f32)
+            .collect();
+        Ok(embedding)
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for OllamaEmbedding {
+    async fn embed(&self, text: &str) -> MnResult<Vec<f32>> {
+        self.embed_one(text).await
+    }
+    async fn embed_batch(&self, texts: &[&str]) -> MnResult<Vec<Vec<f32>>> {
+        let mut out = Vec::with_capacity(texts.len());
+        for t in texts {
+            out.push(self.embed_one(t).await?);
+        }
+        Ok(out)
+    }
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine + subtasks
+// ---------------------------------------------------------------------------
+
+fn build_engine(embedding: Arc<dyn EmbeddingProvider>, dim: usize) -> MnemoEngine {
+    let storage = Arc::new(DuckDbStorage::open_in_memory().unwrap());
+    let index = Arc::new(UsearchIndex::new(dim).unwrap());
+    let ft = Arc::new(TantivyFullTextIndex::open_in_memory().unwrap());
+    MnemoEngine::new(storage, index, embedding, AGENT.to_string(), None).with_full_text(ft)
+}
+
+async fn remember(engine: &MnemoEngine, content: String) -> uuid::Uuid {
+    engine
+        .remember(RememberRequest::new(content))
+        .await
+        .unwrap()
+        .id
+}
+
+async fn remember_linked(engine: &MnemoEngine, content: String, related: uuid::Uuid) -> uuid::Uuid {
+    let mut req = RememberRequest::new(content);
+    req.related_to = Some(vec![related.to_string()]);
+    engine.remember(req).await.unwrap().id
+}
+
+/// Does `auto` (RRF hybrid) recall surface `gold_id` in the top-k for `query`?
+async fn auto_recall_hits(
+    engine: &MnemoEngine,
+    query: &str,
+    gold_id: uuid::Uuid,
+    k: usize,
+) -> bool {
+    let mut req = RecallRequest::new(query.to_string());
+    req.strategy = Some("auto".to_string());
+    req.limit = Some(k);
+    let resp = engine.recall(req).await.unwrap();
+    resp.memories.iter().any(|m| m.id == gold_id)
+}
+
+struct SubtaskResult {
+    label: &'static str,
+    n: usize,
+    hits: usize,
+}
+
+impl SubtaskResult {
+    fn accuracy(&self) -> f64 {
+        self.hits as f64 / self.n.max(1) as f64
+    }
+    /// (point, ci_low, ci_high)
+    fn accuracy_ci(&self) -> (f64, f64, f64) {
+        let (lo, hi) = wilson_95(self.hits, self.n);
+        (self.accuracy(), lo, hi)
+    }
+}
+
+/// Multi-hop: the gold detail is graph-linked to a head the query matches, but
+/// shares no entity token with the query — only graph expansion can bridge it.
+/// Returns `(hits, queries)` for one fixture drawn from `seed`.
+async fn run_multi_hop(
+    make_embedding: &dyn Fn() -> Arc<dyn EmbeddingProvider>,
+    dim: usize,
+    cli: &Cli,
+    seed: u64,
+) -> (usize, usize) {
+    let engine = build_engine(make_embedding(), dim);
+    let mut rng = SplitMix64(seed ^ 0x11_11_11);
+
+    // Seed all clusters first so the corpus (and its distractors) is fully
+    // present before any query runs.
+    let mut golds: Vec<(String, uuid::Uuid)> = Vec::with_capacity(cli.queries);
+    for _ in 0..cli.queries {
+        let person = rng.token();
+        let team = rng.token();
+        let service = rng.token();
+        // Head: matches the query on `person`.
+        let head = remember(
+            &engine,
+            format!("Person {person} leads the {team} engineering team."),
+        )
+        .await;
+        // Gold detail: holds the answer `service`, linked to the head, and
+        // shares NO token with the query (the query never mentions `team`).
+        let gold = remember_linked(
+            &engine,
+            format!("The {team} team owns and operates the {service} service."),
+            head,
+        )
+        .await;
+        // Same-schema distractors (unlinked, unrelated people/teams/services).
+        for _ in 0..cli.distractors {
+            let content = format!(
+                "The {} team owns and operates the {} service.",
+                rng.token(),
+                rng.token()
+            );
+            remember(&engine, content).await;
+        }
+        let query = format!("Which service does the team led by {person} operate?");
+        golds.push((query, gold));
+    }
+
+    let mut hits = 0usize;
+    for (query, gold) in &golds {
+        if auto_recall_hits(&engine, query, *gold, cli.k).await {
+            hits += 1;
+        }
+    }
+    (hits, golds.len())
+}
+
+/// Open-domain: the gold sits among same-schema distractors across the whole
+/// corpus; the query shares the gold's subject entity plus schema words.
+/// Returns `(hits, queries)` for one fixture drawn from `seed`.
+async fn run_open_domain(
+    make_embedding: &dyn Fn() -> Arc<dyn EmbeddingProvider>,
+    dim: usize,
+    cli: &Cli,
+    seed: u64,
+) -> (usize, usize) {
+    let engine = build_engine(make_embedding(), dim);
+    let mut rng = SplitMix64(seed ^ 0x22_22_22);
+
+    let mut golds: Vec<(String, uuid::Uuid)> = Vec::with_capacity(cli.queries);
+    for _ in 0..cli.queries {
+        let subject = rng.token();
+        let answer = rng.token();
+        let gold = remember(
+            &engine,
+            format!("Support ticket about {subject}: the incident was resolved by {answer}."),
+        )
+        .await;
+        for _ in 0..cli.distractors {
+            let content = format!(
+                "Support ticket about {}: the incident was resolved by {}.",
+                rng.token(),
+                rng.token()
+            );
+            remember(&engine, content).await;
+        }
+        let query = format!("Who resolved the support ticket about {subject}?");
+        golds.push((query, gold));
+    }
+
+    let mut hits = 0usize;
+    for (query, gold) in &golds {
+        if auto_recall_hits(&engine, query, *gold, cli.k).await {
+            hits += 1;
+        }
+    }
+    (hits, golds.len())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    // Resolve the embedder. Default = deterministic offline; `--ollama-model`
+    // opts into a real embedder (probed once up front so it fails loud here,
+    // not mid-run).
+    let (embed_backend, dim): (String, usize) = if let Some(ref model) = cli.ollama_model {
+        let probe = OllamaEmbedding::connect(cli.ollama_url.clone(), model.clone()).await?;
+        (format!("ollama:{model}"), probe.dim)
+    } else {
+        (
+            "hash-bag-of-tokens (deterministic, offline)".to_string(),
+            EMBED_DIM,
+        )
+    };
+
+    // A factory so each subtask gets a fresh embedder instance.
+    let url = cli.ollama_url.clone();
+    let model = cli.ollama_model.clone();
+    let make_embedding = move || -> Arc<dyn EmbeddingProvider> {
+        if let Some(ref m) = model {
+            // block_on a fresh connect — the multi-thread runtime allows it;
+            // this path is opt-in and non-deterministic by design.
+            let url = url.clone();
+            let m = m.clone();
+            let handle = tokio::runtime::Handle::current();
+            Arc::new(
+                tokio::task::block_in_place(|| handle.block_on(OllamaEmbedding::connect(url, m)))
+                    .expect("ollama connect"),
+            )
+        } else {
+            Arc::new(HashEmbedding { dim: EMBED_DIM })
+        }
+    };
+
+    // Pool `repeats` fresh fixtures per subtask into one number (n = queries *
+    // repeats), so the HNSW ranking noise floor averages out into the CI.
+    let mut multi_hop = SubtaskResult {
+        label: "multi_hop",
+        n: 0,
+        hits: 0,
+    };
+    let mut open_domain = SubtaskResult {
+        label: "open_domain",
+        n: 0,
+        hits: 0,
+    };
+    for rep in 0..cli.repeats.max(1) {
+        let rep_seed = cli.seed ^ (rep as u64).wrapping_mul(0x9E37_79B1);
+        let (mh, mn) = run_multi_hop(&make_embedding, dim, &cli, rep_seed).await;
+        multi_hop.hits += mh;
+        multi_hop.n += mn;
+        let (oh, on) = run_open_domain(&make_embedding, dim, &cli, rep_seed).await;
+        open_domain.hits += oh;
+        open_domain.n += on;
+    }
+
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let (mh_p, mh_lo, mh_hi) = multi_hop.accuracy_ci();
+    let (od_p, od_lo, od_hi) = open_domain.accuracy_ci();
+
+    // ---- stdout ----
+    println!(
+        "\n=== BEAM-style retrieval bench (hybrid auto/RRF) — {} queries × {} repeats/subtask, \
+         top-{}, seed {:#x}, embedder={} ===",
+        cli.queries, cli.repeats, cli.k, cli.seed, embed_backend
+    );
+    println!(
+        "{:<14} {:>8} {:>8} {:>28}",
+        "subtask", "queries", "hits", "accuracy (95% Wilson)"
+    );
+    for r in [&multi_hop, &open_domain] {
+        let (p, lo, hi) = r.accuracy_ci();
+        println!(
+            "{:<14} {:>8} {:>8} {:>14.1}%  [{:.1}%, {:.1}%]",
+            r.label,
+            r.n,
+            r.hits,
+            p * 100.0,
+            lo * 100.0,
+            hi * 100.0
+        );
+    }
+    println!(
+        "\nReproduced on a synthetic BEAM-STYLE fixture (deterministic, no LLM). NOT the \
+         upstream BEAM dataset; self-reported upstream (Hindsight, 64.1% @ 10M tokens) is an \
+         upper bound and is not directly comparable — see bench/RESULTS.md."
+    );
+
+    // ---- JSON ----
+    let result_json: Vec<serde_json::Value> = [&multi_hop, &open_domain]
+        .iter()
+        .map(|r| {
+            let (p, lo, hi) = r.accuracy_ci();
+            serde_json::json!({
+                "subtask": r.label,
+                "queries": r.n,
+                "hits": r.hits,
+                "accuracy": p,
+                "accuracy_ci95_low": lo,
+                "accuracy_ci95_high": hi,
+            })
+        })
+        .collect();
+    let json = serde_json::json!({
+        "bench": "beam_bench",
+        "style": "BEAM-style multi-hop + open-domain retrieval over hybrid auto/RRF recall",
+        "note": "synthetic deterministic fixture; NOT the upstream 10M-token BEAM dataset; no LLM judge",
+        "upstream_self_reported": { "system": "Hindsight", "beam_accuracy": 0.641, "scale": "10M tokens", "source": "https://hindsight.vectorize.io/blog/2026/04/02/beam-sota" },
+        "date": date,
+        "queries_per_repeat": cli.queries,
+        "repeats": cli.repeats,
+        "distractors_per_gold": cli.distractors,
+        "top_k": cli.k,
+        "seed": cli.seed,
+        "embedder": embed_backend,
+        "hnsw_noise_note": "vector lane is USearch HNSW (approximate NN); repeats pooled to average the run-to-run ranking noise floor into the Wilson CI",
+        "results": result_json,
+    });
+
+    // ---- Markdown ----
+    let md = format!(
+        "# BEAM-style retrieval bench — multi-hop + open-domain (hybrid auto/RRF)\n\n\
+         > {date} — reproducible retrieval bench over mnemo's default hybrid recall \
+         (`strategy=\"auto\"`: semantic + BM25 + graph-expansion + recency, RRF-fused). \
+         **Synthetic deterministic fixture, no LLM** — this is NOT the upstream BEAM \
+         dataset. See the honesty note in [`bench/RESULTS.md`](../../RESULTS.md).\n\n\
+         - **{q} queries × {reps} repeats/subtask** (n={mn}), {d} distractors/gold, top-{k}, \
+         seed `{seed:#x}`, embedder `{eb}`.\n\
+         - *Accuracy* = fraction of queries whose gold memory is in the top-{k} (Wilson 95%). \
+         Repeats are pooled to average the USearch HNSW approximate-NN ranking noise floor into \
+         the CI (same treatment `semantic_recall_bench` documents).\n\n\
+         | subtask | queries | hits | **accuracy** (95% Wilson) |\n\
+         |---|---:|---:|---:|\n\
+         | `multi_hop` (graph-linked answer, no shared query token) | {mn} | {mh} | **{mp:.1}%** [{mlo:.1}%, {mhi:.1}%] |\n\
+         | `open_domain` (gold among same-schema distractors) | {on} | {oh} | **{op:.1}%** [{olo:.1}%, {ohi:.1}%] |\n\n\
+         **Reproduced vs self-reported.** These numbers are reproduced on *this* synthetic \
+         fixture. Upstream **BEAM** (Hindsight, self-reported **64.1%** at 10M tokens, \
+         [source](https://hindsight.vectorize.io/blog/2026/04/02/beam-sota)) runs a vastly \
+         larger real corpus scored by an LLM judge. Self-reported memory scores are an \
+         **upper bound** (vendor-run, not independently reproduced across labs), and our \
+         fixture number is **not comparable** to it — do not read the two as a ranking. \
+         Reproduce: `cargo run --release -p mnemo-locomo-bench --bin beam_bench`.\n",
+        q = cli.queries,
+        reps = cli.repeats,
+        d = cli.distractors,
+        k = cli.k,
+        seed = cli.seed,
+        eb = embed_backend,
+        mn = multi_hop.n,
+        mh = multi_hop.hits,
+        mp = mh_p * 100.0,
+        mlo = mh_lo * 100.0,
+        mhi = mh_hi * 100.0,
+        on = open_domain.n,
+        oh = open_domain.hits,
+        op = od_p * 100.0,
+        olo = od_lo * 100.0,
+        ohi = od_hi * 100.0,
+        date = date,
+    );
+
+    std::fs::create_dir_all(&cli.out_dir).ok();
+    let md_path = cli.out_dir.join(format!("beam_{date}.md"));
+    let json_path = cli.out_dir.join(format!("beam_{date}.json"));
+    std::fs::write(&md_path, md)?;
+    std::fs::write(&json_path, serde_json::to_string_pretty(&json)?)?;
+    println!("\nwrote {}", md_path.display());
+    println!("wrote {}", json_path.display());
+    Ok(())
+}

--- a/bench/locomo/src/lib.rs
+++ b/bench/locomo/src/lib.rs
@@ -27,6 +27,7 @@ pub mod judge;
 pub mod phase_cost;
 pub mod runner;
 pub mod scoring;
+pub mod stats;
 
 pub use judge::{JudgeModel, JudgeVerdict, LoCoMoJudge, MockJudge};
 pub use phase_cost::{

--- a/bench/locomo/src/stats.rs
+++ b/bench/locomo/src/stats.rs
@@ -1,0 +1,50 @@
+//! Shared statistics helpers for the bench bins.
+//!
+//! Centralised so every bench reports intervals the same way instead of each
+//! bin re-deriving the formula.
+
+/// Wilson 95% score interval for `successes`/`n` (z = 1.96). Returns
+/// `(low, high)` clamped to `[0, 1]`.
+///
+/// Preferred over the normal approximation for proportions near 0 or 1 and for
+/// small `n` — which is exactly the regime the bench accuracy numbers live in.
+pub fn wilson_95(successes: usize, n: usize) -> (f64, f64) {
+    if n == 0 {
+        return (0.0, 0.0);
+    }
+    let z = 1.959_963_984_540_054_f64;
+    let n = n as f64;
+    let p = successes as f64 / n;
+    let z2 = z * z;
+    let denom = 1.0 + z2 / n;
+    let center = (p + z2 / (2.0 * n)) / denom;
+    let margin = (z / denom) * (p * (1.0 - p) / n + z2 / (4.0 * n * n)).sqrt();
+    ((center - margin).max(0.0), (center + margin).min(1.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wilson_95;
+
+    #[test]
+    fn zero_n_is_degenerate() {
+        assert_eq!(wilson_95(0, 0), (0.0, 0.0));
+    }
+
+    #[test]
+    fn interval_brackets_point_estimate() {
+        let (lo, hi) = wilson_95(80, 100);
+        assert!(
+            lo < 0.80 && 0.80 < hi,
+            "80/100 CI must bracket 0.8: [{lo}, {hi}]"
+        );
+        assert!(lo >= 0.0 && hi <= 1.0);
+    }
+
+    #[test]
+    fn perfect_score_upper_is_one_lower_below_one() {
+        let (lo, hi) = wilson_95(50, 50);
+        assert!((hi - 1.0).abs() < 1e-9);
+        assert!(lo < 1.0, "a finite sample can't prove 100%: lo={lo}");
+    }
+}

--- a/crates/mnemo-core/tests/version_metadata.rs
+++ b/crates/mnemo-core/tests/version_metadata.rs
@@ -10,11 +10,11 @@
 //! [docs/compat/version-skew-matrix.md](../../docs/compat/version-skew-matrix.md).
 
 #[test]
-fn cargo_pkg_version_matches_v0_5_7() {
+fn cargo_pkg_version_matches_v0_5_8() {
     assert_eq!(
         env!("CARGO_PKG_VERSION"),
-        "0.5.7",
-        "mnemo-core CARGO_PKG_VERSION drifted from the v0.5.7 cut. \
+        "0.5.8",
+        "mnemo-core CARGO_PKG_VERSION drifted from the v0.5.8 cut. \
          Bump `workspace.package.version` in /Cargo.toml AND update \
          docs/compat/version-skew-matrix.md to match."
     );

--- a/docs/compat/version-skew-matrix.md
+++ b/docs/compat/version-skew-matrix.md
@@ -1,6 +1,9 @@
 # Mnemo Version Skew Matrix
 
-> Updated 2026-07-04 for the v0.5.7 cut (real **pgvector ANN search** on the
+> Updated 2026-07-04 for the v0.5.8 cut (reproducible **BEAM-style** multi-hop /
+> open-domain retrieval bench — a new `beam_bench` bin + a shared `stats::wilson_95`
+> helper + docs; bench-and-docs only, no dependency or API change from v0.5.7).
+> The v0.5.7 cut added real **pgvector ANN search** on the
 > PostgreSQL backend — semantic/hybrid/graph/domain-scoped recall now returns
 > results via the HNSW cosine index; #99. Implements a previously-stubbed
 > capability; no `VectorIndex` trait API change, no dependency change from
@@ -31,7 +34,8 @@ source-of-truth — see [CHANGELOG](../../CHANGELOG.md)).
 
 | `mnemo` (Cargo workspace) | `rmcp` | `tantivy` | `usearch` | `duckdb` | `pgvector` | `sqlx` | Cloudflare substrate ³ |
 |---|---|---|---|---|---|---|---|
-| **0.5.7** (2026-07-04) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
+| **0.5.8** (2026-07-04) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
+| 0.5.7 (2026-07-04) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.5.6 (2026-07-02) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.5.5 (2026-07-03) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
 | 0.5.4 (2026-06-27) | 1.3 | 0.26 | 2.21 | 1.10504.0 ⁴ | 0.8.2 | 0.8 | Workers KV+Vectorize + DO Facets SQLite ³ |
@@ -53,7 +57,8 @@ source-of-truth — see [CHANGELOG](../../CHANGELOG.md)).
 
 | `mnemo` | Python SDK (`mnemo-db`) | TS SDK (`@mndfreek/mnemo-sdk`) | Go SDK (`mnemo.Version`) | `mcp-python` ⁵ | `mcp-go` ⁵ | `mcp-ruby` ⁵ | `mcp-csharp` ⁵ |
 |---|---|---|---|---|---|---|---|
-| **0.5.7** (2026-07-04) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
+| **0.5.8** (2026-07-04) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
+| 0.5.7 (2026-07-04) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
 | 0.5.6 (2026-07-02) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
 | 0.5.5 (2026-07-03) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |
 | 0.5.4 (2026-06-27) ⁶ | (unchanged) | (unchanged) | (unchanged) | 1.13.x | 0.31.x | 0.5.x | 0.4.x |


### PR DESCRIPTION
## Summary

Adds a **reproducible** BEAM-style retrieval benchmark and publishes the number with an explicit honesty note. New bin `beam_bench` (`mnemo-locomo-bench`) runs two BEAM-style subtasks over mnemo's default hybrid `auto`/RRF recall (semantic + BM25 + graph-expansion + recency):

- **multi_hop** — the gold answer lives in a memory graph-linked (`related_to`) to a memory the query matches, but shares **no** entity token with the query; only graph expansion can bridge it.
- **open_domain** — the gold sits among same-schema distractors across the corpus.

Per-subtask accuracy is reported with a **Wilson 95%** interval, reusing the shared `mnemo_locomo_bench::stats::wilson_95` helper (extracted from `asi06_resistance`, which now imports it instead of keeping a copy).

## Result (this run, seed `0xbea320262026`)

| subtask | reproduced (this fixture) | self-reported (upstream) |
|---|---:|---:|
| `multi_hop` | **0.6%** (3/500) [95% 0.2–1.7%] | — (BEAM reports one overall score) |
| `open_domain` | **68.6%** (343/500) [95% 64.4–72.5%] | Hindsight BEAM **64.1%** @ 10M tokens ([source](https://hindsight.vectorize.io/blog/2026/04/02/beam-sota)) |

**Not a ranking.** The reproduced numbers are on a *small synthetic fixture* with a lexical offline embedder and **no LLM judge**; upstream 64.1% is the real 10M-token, LLM-graded BEAM. Self-reported memory scores are a vendor-run **upper bound** (not independently reproduced across labs) and are **not comparable** to a synthetic fixture. The low `multi_hop` figure is honest, not a bug — default `auto` RRF barely surfaces a graph-only answer against lexically-equivalent distractors; the `graph`/`reconstruct` strategies target multi-hop. No "first"/"best" claim.

## Reproducibility

- **Deterministic + offline by default:** hashed bag-of-tokens embedder (no network, no LLM), fixed seed, 100 queries × 5 **pooled** repeats/subtask. Repeats are pooled to average the USearch HNSW approximate-NN ranking noise floor into the CI (the treatment `semantic_recall_bench` documents). Two back-to-back runs produced **identical** pooled counts (3/500, 343/500).
- A real-embedder path is gated behind `--ollama-model` and **fails loud** if Ollama is unreachable — never a silent/unreproducible number.
- Reproduce: `cargo run --release -p mnemo-locomo-bench --bin beam_bench` (writes `bench/locomo/results/beam_<date>.{md,json}`).

## Also

- Corrected `bench/RESULTS.md`'s now-stale backend note (pgvector semantic recall is implemented as of v0.5.7, #99).
- Version `0.5.7 → 0.5.8` (patch: new bench bin + shared helper + docs; no engine/protocol API change). **Note:** the task said `0.5.6 → 0.5.7`, but `main` is already at `0.5.7` (the #99 pgvector work merged there), so this cut is `0.5.8`.

## Test plan

- `cargo build --release -p mnemo-locomo-bench` ✅ and `cargo run --release -p mnemo-locomo-bench --bin beam_bench` ✅ (number captured into RESULTS.md)
- `cargo test -p mnemo-locomo-bench -p mnemo-core` ✅ (new `stats::wilson_95` tests + `version_metadata` 0.5.8)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ · `cargo fmt --all -- --check` ✅ · README fence + marketing-lint ✅

Lands as a PR (not a push to `main`) so the version-gated crates.io publish does not fire; a `v0.5.8` tag can follow once CI is green. `KILL_CRITERIA.md` (untracked) intentionally not committed. The pre-existing `mnemo-golem-wit` linker failure keeps the CI Build/Test jobs red — unrelated to this change.
